### PR TITLE
fix: Fix pypcode version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "capstone>=4.0.2,<5",
         "networkx>=2.4,<3",
         "protobuf>=3.12.2,<4",
-        "pypcode>=1.0.7,<2",
+        "pypcode>=1.0.7,<1.1.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
There is an issue with the last version of `pypcode` ( https://github.com/angr/pypcode/issues/44 ) that prevents us to install it.

This PR fixes it by pinning the dependency.