### PR TITLE
doc: Add last modification date in the documentation

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,10 @@ plugins:
       scripts:
         - docs/gen_ref_pages.py
   - literate-nav
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+      fallback_to_build_date: true
   - mkdocstrings:
       watch:
         - bindings/python/quokka

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
             "mkdocstrings",
             "mkdocstrings-python",
             "mkdocs-literate-nav",
+            "mkdocs-git-revision-date-localized-plugin",
             "mkdocs-gen-files",
             "mkdocs-simple-hooks",
         ],


### PR DESCRIPTION
This PR adds a dependency on [mkdocs-git-revision-date](https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/index.html) for MkDocs

It allows to add the date of modification / creation at the end of each documentation file.