### PR TITLE
dep: Upgrade pypcode dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "capstone>=4.0.2,<5",
         "networkx>=2.4,<3",
         "protobuf>=3.12.2,<4",
-        "pypcode>=1.0.7,<1.1.0",
+        "pypcode>=1.1.1,<2",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Pypcode can be upgraded thanks to https://github.com/angr/pypcode/pull/45 