### PR TITLE
Update abseil to 20220623.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (NOT NO_BUILD)
     FetchContent_Declare(
             abseil
             GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-            GIT_TAG 20211102.0
+            GIT_TAG 20220623.1
     )
     FetchContent_MakeAvailable(abseil)
 


### PR DESCRIPTION
The previous version has not been updated in 2 years and it's failing the compilation on modern compilers (clang 15.0.7 / gcc 13.1.1)