### PR TITLE
Add support for older IDA versions (7.0 - 7.4).

### DIFF
--- a/src/Quokka.cpp
+++ b/src/Quokka.cpp
@@ -158,6 +158,7 @@ ssize_t idaapi UIHook(void* /* not used */, int event_id,
 
   // set_database_flag(DBFL_KILL);
   qexit(0);
+  return 0;
 }
 
 void SetLogLevel() {
@@ -277,14 +278,34 @@ void idaapi PluginTerminate() {
 
 }  // namespace quokka
 
+#if IDA_SDK_VERSION > 740
 static plugmod_t* idaapi init() { return new quokka::plugin_ctx_t; }
+#else
+int idaapi init(void) {
+	quokka::PluginInit();
+	return PLUGIN_KEEP;
+}
+
+void idaapi term(void)
+{
+  quokka::PluginTerminate();
+}
+
+bool idaapi run(size_t args) {
+	return quokka::PluginRun(args);
+};
+#endif
 
 plugin_t PLUGIN{
     IDP_INTERFACE_VERSION,
+#if IDA_SDK_VERSION > 740
     PLUGIN_UNL | PLUGIN_MULTI,
+#else
+    PLUGIN_UNL,
+#endif
     init,
-    nullptr,
-    nullptr,
+    term,
+    run,
     "This module exports binary",
     "Quokka help",
     "Quokka",

--- a/src/Quokka.cpp
+++ b/src/Quokka.cpp
@@ -158,7 +158,6 @@ ssize_t idaapi UIHook(void* /* not used */, int event_id,
 
   // set_database_flag(DBFL_KILL);
   qexit(0);
-  return 0;
 }
 
 void SetLogLevel() {

--- a/src/Quokka.cpp
+++ b/src/Quokka.cpp
@@ -300,12 +300,15 @@ plugin_t PLUGIN{
     IDP_INTERFACE_VERSION,
 #if IDA_SDK_VERSION > 740
     PLUGIN_UNL | PLUGIN_MULTI,
+    init,
+    nullptr,
+    nullptr,
 #else
     PLUGIN_UNL,
-#endif
     init,
     term,
     run,
+#endif
     "This module exports binary",
     "Quokka help",
     "Quokka",


### PR DESCRIPTION
FWIW: This patch adds support for older IDA versions, such as the 7.4 release that I'm still using.
I am not sure if this is particularly useful, but the changes are fairly simple.

Tested on Windows 10 (amd64, Build 19045.3086) and IDA Pro 7.4.