### PR TITLE
Add several APIs

### DIFF
--- a/bindings/python/quokka/block.py
+++ b/bindings/python/quokka/block.py
@@ -235,7 +235,7 @@ class Block(MutableMapping):
             return b""
 
         # Read all block at once
-        block_bytes = self.program.executable.read_byte(
+        block_bytes = self.program.executable.read_bytes(
             offset=file_offset,
             size=self.size,
         )

--- a/bindings/python/quokka/executable.py
+++ b/bindings/python/quokka/executable.py
@@ -16,7 +16,6 @@
 
 import pathlib
 import struct
-import warnings
 
 from quokka.types import DataType, Endianness, Literal, Optional, Union
 
@@ -184,10 +183,3 @@ class Executable:
             The bytes values
         """
         return self.read(offset, size)
-
-    def read_byte(self, offset: int, size: int) -> bytes:
-        """Deprecated. Use read_bytes"""
-        warnings.warn(
-            "read_byte has been deprecated. Please use read_bytes", DeprecationWarning
-        )
-        return self.read_bytes(offset, size)

--- a/bindings/python/quokka/executable.py
+++ b/bindings/python/quokka/executable.py
@@ -16,6 +16,7 @@
 
 import pathlib
 import struct
+import warnings
 
 from quokka.types import DataType, Endianness, Literal, Optional, Union
 
@@ -185,6 +186,8 @@ class Executable:
         return self.read(offset, size)
 
     def read_byte(self, offset: int, size: int) -> bytes:
-        """Deprecated"""
-        DeprecationWarning("read_byte has been deprecated. Please use read_bytes")
+        """Deprecated. Use read_bytes"""
+        warnings.warn(
+            "read_byte has been deprecated. Please use read_bytes", DeprecationWarning
+        )
         return self.read_bytes(offset, size)

--- a/bindings/python/quokka/function.py
+++ b/bindings/python/quokka/function.py
@@ -708,6 +708,14 @@ class Function(dict):
         """Function in degree"""
         return self[self.start].in_degree
 
+    @property
+    def blocks(self) -> dict[AddressT, quokka.Block]:
+        """Returns a dictionary which is used to reference all basic blocks
+        by their address.
+        Calling this function will also load the CFG.
+        """
+        return {addr: self.get_block(addr) for addr in self.graph.nodes}
+
     def __hash__(self) -> int:  # type: ignore
         """Hash value"""
         return self.start

--- a/bindings/python/quokka/instruction.py
+++ b/bindings/python/quokka/instruction.py
@@ -359,7 +359,7 @@ class Instruction:
         except quokka.exc.NotInFileError:
             return b""
 
-        return self.program.executable.read_byte(
+        return self.program.executable.read_bytes(
             offset=file_offset,
             size=self.size,
         )

--- a/bindings/python/quokka/program.py
+++ b/bindings/python/quokka/program.py
@@ -440,7 +440,7 @@ class Program(dict):
                 if chunk.chunk_type in chunk_types:
                     yield chunk
 
-    def read_byte(self, v_addr: AddressT, size: int) -> bytes:
+    def read_bytes(self, v_addr: AddressT, size: int) -> bytes:
         """Read raw bytes from a virtual address
 
         Arguments:
@@ -453,7 +453,7 @@ class Program(dict):
 
         if (offset := v_addr - self.base_address) < 0:
             raise ValueError("Address outside virtual address space.")
-        return self.executable.read_byte(offset, size)
+        return self.executable.read_bytes(offset, size)
 
     def get_data(self, address: AddressT) -> quokka.Data:
         """Get data by address

--- a/bindings/python/quokka/program.py
+++ b/bindings/python/quokka/program.py
@@ -440,6 +440,21 @@ class Program(dict):
                 if chunk.chunk_type in chunk_types:
                     yield chunk
 
+    def read_byte(self, v_addr: AddressT, size: int) -> bytes:
+        """Read raw bytes from a virtual address
+
+        Arguments:
+            v_addr: Virtual address of the data to read
+            size: Size of the data to read
+
+        Returns:
+            The raw data at the specified address
+        """
+
+        if (offset := v_addr - self.base_address) < 0:
+            raise ValueError("Address outside virtual address space.")
+        return self.executable.read_byte(offset, size)
+
     def get_data(self, address: AddressT) -> quokka.Data:
         """Get data by address
 

--- a/bindings/python/quokka/types.py
+++ b/bindings/python/quokka/types.py
@@ -48,6 +48,13 @@ LocationValueType = Union[
 
 RegType = enum.IntEnum
 
+class RegAccessMode(enum.Enum):
+    """Register access mode"""
+
+    READ = enum.auto()
+    WRITE = enum.auto()
+    ANY = enum.auto()
+
 ReferenceTarget = Union[
     "quokka.structure.Structure",
     "quokka.structure.StructureMember",

--- a/bindings/python/quokka/utils.py
+++ b/bindings/python/quokka/utils.py
@@ -14,10 +14,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from __future__ import annotations
 import functools
 import hashlib
 import pathlib
 import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import quokka
 from quokka.analysis import (
@@ -34,7 +37,10 @@ from quokka.analysis import (
     ArchPPC64,
 )
 
-from quokka.types import Type
+from quokka.types import Type, RegAccessMode
+
+if TYPE_CHECKING:
+    from quokka.instruction import Instruction
 
 logger = logging.getLogger()
 
@@ -177,3 +183,36 @@ def parse_version(version: str) -> tuple[int, int, int]:
         )
 
     return parsed
+
+
+def find_reg_access(
+    reg_id: int, access_mode: RegAccessMode, instructions: Iterable[Instruction]
+) -> Instruction | None:
+    """Traverse the list of instructions searching for the first one that access
+    the specified register with the required access mode.
+
+    Arguments:
+        reg: The capstone register ID that we are targeting (ex: capstone.x86_const.X86_REG_EAX)
+        access_mode: The access mode to the register (read or write)
+        instructions: An iterable of instructions to analyze
+
+    Returns:
+        The first instruction that access the register in the specified mode.
+        Return None if no such instruction is found.
+    """
+
+    for instr in instructions:
+        # Retrieve the list of all registers read or modified by the instruction using capstone
+        regs_read, regs_write = instr.cs_inst.regs_access()
+
+        # Check if it is accessing the target register in the correct mode
+        if (
+            reg_id in regs_write
+            and (access_mode == RegAccessMode.WRITE or access_mode == RegAccessMode.ANY)
+        ) or (
+            reg_id in regs_read
+            and (access_mode == RegAccessMode.READ or access_mode == RegAccessMode.ANY)
+        ):
+            return instr
+
+    return None

--- a/bindings/python/quokka/utils.py
+++ b/bindings/python/quokka/utils.py
@@ -185,7 +185,7 @@ def parse_version(version: str) -> tuple[int, int, int]:
     return parsed
 
 
-def find_reg_access(
+def find_register_access(
     reg_id: int, access_mode: RegAccessMode, instructions: Iterable[Instruction]
 ) -> Instruction | None:
     """Traverse the list of instructions searching for the first one that access

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     description="Quokka : A Fast and Accurate Binary Exporter",
     long_description=readme,
     long_description_content_type="text/markdown",
+    python_requires=">=3.8",
     packages=["quokka", "quokka.analysis", "quokka.backends"],
     package_dir={"": "bindings/python/"},
     package_data={"quokka": ["*.pyi", "*.typed"]},


### PR DESCRIPTION
List of introduces APIs:

 - `Program.read_bytes`, reads memory from virtual address
 - `utils.find_reg_access`, finds the first instruction accessing a target register

`Executable.read_byte` has been deprecated in favor of `Executable.read_bytes`