### PR TITLE
Always resize the last chunk

### DIFF
--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -345,6 +345,8 @@ int ExportLayout(quokka::Quokka* proto) {
     head_iterator.NextAddressAndState();
 
     if (head_iterator.state == FINISH) {
+      if (head_iterator.current_chunk != nullptr)
+        head_iterator.current_chunk->Resize(BADADDR);
       QLOGI << absl::StrFormat("End export layout in %.2fs",
                                timer.ElapsedSeconds(absl::Now()));
       break;


### PR DESCRIPTION
This might cause errors when having a fake chunk as the very last chunk in the code. This might happen when having some orphan asm code at the very end.
If we don't resize it, that fake chunk will have `end_addr == BADADDR`, so it will basically be unlimited. This might result in errors when binary searching for chunks.