### PR TITLE
update pypcode to use version >2.0.0

### DIFF
--- a/bindings/python/quokka/block.py
+++ b/bindings/python/quokka/block.py
@@ -243,7 +243,7 @@ class Block(MutableMapping):
 
         return block_bytes
 
-    @property
+    @cached_property
     def pcode_insts(self) -> List[pypcode.PcodeOp]:
         """Generate PCode instructions for the block
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ test = [
     "pytest-mock",
     "pytest-cov",
     "coverage[toml]",
-    "pypcode>=1.1.1",
+    "pypcode>=1.1.2",
 ]
-pypcode = ["pypcode>=1.1.1"]
+pypcode = ["pypcode>=1.1.2"]
 doc = [
     "mkdocs",
     "mkdocs-material",
@@ -45,7 +45,7 @@ dev = [
     "mypy",
     "mypy-protobuf",
     "nox",
-    "pypcode>=1.1.1",
+    "pypcode>=1.1.2",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ test = [
     "pytest-mock",
     "pytest-cov",
     "coverage[toml]",
-    "pypcode>=1.1.2",
+    "pypcode>=2.0.0",
 ]
-pypcode = ["pypcode>=1.1.2"]
+pypcode = ["pypcode>=2.0.0"]
 doc = [
     "mkdocs",
     "mkdocs-material",
@@ -45,7 +45,7 @@ dev = [
     "mypy",
     "mypy-protobuf",
     "nox",
-    "pypcode>=1.1.2",
+    "pypcode>=2.0.0",
 ]
 
 [tool.setuptools]

--- a/tests/python/tests/backends/test_pypcode.py
+++ b/tests/python/tests/backends/test_pypcode.py
@@ -8,16 +8,16 @@ import quokka.backends.pypcode as pypcode_backend
 def test_pypcode_context():
 
     context = pypcode_backend.get_pypcode_context(quokka.analysis.ArchX86)
-    assert context.lang.id == "x86:LE:32:default"
+    assert context.language.id == "x86:LE:32:default"
 
     context = pypcode_backend.get_pypcode_context(quokka.analysis.ArchX64)
-    assert context.lang.id == "x86:LE:64:default"
+    assert context.language.id == "x86:LE:64:default"
 
     context = pypcode_backend.get_pypcode_context(quokka.analysis.ArchARM64)
-    assert context.lang.id == "AARCH64:LE:64:v8A"
+    assert context.language.id == "AARCH64:LE:64:v8A"
 
     context = pypcode_backend.get_pypcode_context(quokka.analysis.ArchARM)
-    assert context.lang.id == "ARM:LE:32:v8"
+    assert context.language.id == "ARM:LE:32:v8"
 
     with pytest.raises(quokka.PypcodeError):
         pypcode_backend.get_pypcode_context(quokka.analysis.QuokkaArch)


### PR DESCRIPTION
Quokka was enforcing pypcode<2, but a new version 2.0.0 was released. This merge request updates the pypcode part to use the latest version. The following things have changed.

* ``ContextObj`` is no longer exposed
* ``Context.translate``, returns a ``TranslationResult`` which sole attribute is directly a list of ``PcodeOps``. No more instructions

This merge request changes the following:
* change ``ContextObj`` to ``Context`` object.
* remove ``combine_instructions()`` as translating a block returns directly a list of PcodeOps
* remove the equality and object_hash monkey patching. Its was problematic to port, and not sure it was really useful ? And used for ? (ping @DarkaMaul )

Shall be prooftested before merging...