### PR TITLE
[python] Fix the Function.calls semantic

### DIFF
--- a/bindings/python/quokka/function.py
+++ b/bindings/python/quokka/function.py
@@ -289,16 +289,20 @@ class Chunk(MutableMapping, Iterable):
     @property
     def calls(self) -> List[quokka.Chunk]:
         """Return the list of calls made by this chunk.
+        The semantic of a "call" is to jump or call to the **starting** chunk of a function.
+        Beware that this might lead to different results than the program call graph.
 
         Note: The list is not deduplicated so a target may occur multiple time.
         """
 
         calls = []
         for inst_instance in self.program.references.resolve_calls(self, towards=False):
-            if isinstance(inst_instance, tuple):
-                calls.append(inst_instance[0])
-            else:
-                calls.append(inst_instance)
+            chunk = (
+                inst_instance[0] if isinstance(inst_instance, tuple) else inst_instance
+            )
+            # Check that the chunk is the **starting** chunk of a function
+            if chunk.start in self.program:
+                calls.append(chunk)
 
         return calls
 


### PR DESCRIPTION
Change the semantic of `Function.calls()` so that it will return only the **starting** chunks that are called from the current function. A starting chunk means that it is the first chunk of a function.

By definition a function has **ONE** entry point and >=0 exit point.