### PR TITLE
Update LLVM ref to LLVM@18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
                 -G Ninja \
                 -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
                 -DIdaSdk_ROOT_DIR=${GITHUB_WORKSPACE}/third_party/$IDA_SDK_VERSION \
-                -DLLVM_ROOT=$(brew --prefix llvm@15)
+                -DLLVM_ROOT=$(brew --prefix llvm@18)
 
       - name: Prepare build environment (Windows)
         if: ${{ matrix.os == 'windows-latest' }}


### PR DESCRIPTION
`macos-latest`runner now has llvm@18 instead of 15.

Source: https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md