### PR TITLE
Add Protobuf LZMA compression for file on disk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -407,6 +407,22 @@ jobs:
           path: third_party/idasdk${{ matrix.ida_sdk }}
           key: idasdk-${{ runner.os }}-${{ matrix.ida_sdk }}-${{ hashFiles('sdk_lockfile') }}
 
+      - name: Install liblzma (Linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liblzma-dev
+
+      - name: Install liblzma (MacOS)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          brew install xz
+
+      - name: Install liblzma (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          vcpkg install liblzma:x64-windows
+
       - name: Prepare build environment (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,8 @@ if (NOT NO_BUILD)
     # Include protobuf functions
     include(cmake/protobuf.cmake)
 
+    find_package(LibLZMA REQUIRED)
+
     find_package(IdaSdk REQUIRED)
 
     add_subdirectory(proto)

--- a/bindings/python/quokka/program.py
+++ b/bindings/python/quokka/program.py
@@ -27,6 +27,7 @@ import os
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Type, Iterable
+import lzma
 
 import capstone
 import networkx
@@ -107,10 +108,17 @@ class Program(dict):
         """Constructor"""
         super(dict, self).__init__()
 
-        self.proto = Pb() # type: ignore
+        self.proto: quokka.pb.Quokka = quokka.pb.Quokka()
         self.export_file: Path = Path(export_file)
-        with open(self.export_file, "rb") as fd:
-            self.proto.ParseFromString(fd.read())
+        try:
+            with lzma.open(self.export_file, "rb") as fd:
+                raw_data = fd.read()
+        except lzma.LZMAError:
+            # try reading it as a plain-bytes Quokka (but should raise version mismatch later)
+            with open(self.export_file, "rb") as fd:
+                raw_data = fd.read()
+
+        self.proto.ParseFromString(raw_data)
 
         # Export mode
         self.mode: ExporterMode = ExporterMode.from_proto(self.proto.exporter_meta.mode)

--- a/ghidra_extension/build.gradle
+++ b/ghidra_extension/build.gradle
@@ -31,6 +31,7 @@ def protobufVersion = '4.31.0'
 
 dependencies {
     compileOnly "com.google.protobuf:protobuf-java:${protobufVersion}"
+    implementation 'org.tukaani:xz:1.12'
 
     testImplementation "com.google.protobuf:protobuf-java:${protobufVersion}"
     testImplementation 'junit:junit:4.13.2'
@@ -45,6 +46,13 @@ protobuf {
 
 // Ensure proto generation runs before compilation
 compileJava.dependsOn 'generateProto'
+
+// Ghidra's copyDependencies copies implementation JARs to lib/.
+// The protobuf plugin's extractIncludeProto scans those same JARs,
+// so it must run after copyDependencies to avoid implicit dependency errors.
+tasks.matching { it.name.startsWith('extractInclude') && it.name.endsWith('Proto') }.configureEach {
+    dependsOn 'copyDependencies'
+}
 
 test {
     useJUnit()

--- a/ghidra_extension/src/main/java/com/quarkslab/quokka/ExportPipeline.java
+++ b/ghidra_extension/src/main/java/com/quarkslab/quokka/ExportPipeline.java
@@ -8,6 +8,9 @@ import ghidra.util.Msg;
 import ghidra.util.task.TaskMonitor;
 import quokka.QuokkaOuterClass.Quokka;
 
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.XZOutputStream;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Iterator;
@@ -89,17 +92,26 @@ public class ExportPipeline {
         monitor.setMessage("Quokka: collecting headers...");
         builder.setHeaders(collectHeaders(program));
 
-        // Phase 8: Serialize
-        monitor.setMessage("Quokka: writing protobuf...");
+        // Phase 8: Compress & serialize (LZMA/XZ)
+        monitor.setMessage("Quokka: compressing & writing protobuf...");
         Quokka proto = builder.build();
-        try (FileOutputStream fos = new FileOutputStream(outputFile)) {
-            proto.writeTo(fos);
+        int rawSize = proto.getSerializedSize();
+        try (FileOutputStream fos = new FileOutputStream(outputFile);
+             XZOutputStream xzOut = new XZOutputStream(fos, new LZMA2Options())) {
+            proto.writeTo(xzOut);
         }
 
+        long compressedSize = outputFile.length();
         long elapsed = System.currentTimeMillis() - startTime;
+        if (rawSize > 0) {
+            Msg.info(ExportPipeline.class, String.format(
+                    "Compressed %d bytes -> %d bytes (%.1f%%)",
+                    rawSize, compressedSize,
+                    100.0 * (rawSize - compressedSize) / rawSize));
+        }
         Msg.info(ExportPipeline.class, "Quokka export complete in " + elapsed
                 + "ms -> " + outputFile.getAbsolutePath()
-                + " (" + outputFile.length() + " bytes)");
+                + " (" + compressedSize + " bytes)");
     }
 
     /**

--- a/include/quokka/Logger.h
+++ b/include/quokka/Logger.h
@@ -187,6 +187,18 @@ class Logger {
   }
 
   /**
+   * Flush all pending log messages
+   */
+  void Flush() {
+    fflush(stderr);
+    fflush(stdout);
+    if (m_defaultui) {
+      // Force IDA to flush its message buffer
+      refresh_idaview_anyway();
+    }
+  }
+
+  /**
    * Singleton pattern
    * @return An instance to self
    */

--- a/include/quokka/LzmaStreambuf.h
+++ b/include/quokka/LzmaStreambuf.h
@@ -1,0 +1,138 @@
+// Copyright 2022-2023 Quarkslab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file LzmaStreambuf.h
+ * A std::streambuf that LZMA-compresses data on-the-fly.
+ */
+
+#ifndef QUOKKA_LZMA_STREAMBUF_H
+#define QUOKKA_LZMA_STREAMBUF_H
+
+#include <cstdint>
+#include <ostream>
+#include <streambuf>
+
+#include <lzma.h>
+
+namespace quokka {
+
+/**
+ * A std::streambuf that LZMA-compresses data on-the-fly and writes the
+ * compressed output directly to a destination std::ostream.
+ *
+ * Usage:
+ *   std::ofstream file("out.bin", std::ios::binary);
+ *   LzmaStreambuf lzma_buf(file);
+ *   std::ostream lzma_out(&lzma_buf);
+ *   protobuf.SerializeToOstream(&lzma_out);
+ *   lzma_buf.finish();  // flush & finalize the LZMA stream
+ */
+class LzmaStreambuf : public std::streambuf {
+ public:
+  explicit LzmaStreambuf(std::ostream& dest,
+                         uint32_t preset = LZMA_PRESET_DEFAULT)
+      : dest_(dest), lzma_stream_(LZMA_STREAM_INIT), finished_(false) {
+    lzma_ret ret = lzma_easy_encoder(&lzma_stream_, preset, LZMA_CHECK_CRC64);
+    if (ret != LZMA_OK) {
+      ok_ = false;
+      return;
+    }
+    ok_ = true;
+    setp(in_buf_, in_buf_ + kBufSize);
+  }
+
+  ~LzmaStreambuf() override {
+    if (!finished_) finish();
+    lzma_end(&lzma_stream_);
+  }
+
+  // Non-copyable, non-movable
+  LzmaStreambuf(const LzmaStreambuf&) = delete;
+  LzmaStreambuf& operator=(const LzmaStreambuf&) = delete;
+
+  /// Finalize the LZMA stream (must be called before reading sizes).
+  bool finish() {
+    if (finished_) return ok_;
+    finished_ = true;
+    // Flush whatever remains in the put-area, then signal LZMA_FINISH.
+    ok_ = flush_to_lzma(LZMA_FINISH) && ok_;
+    return ok_;
+  }
+
+  bool ok() const { return ok_; }
+  uint64_t total_in() const { return lzma_stream_.total_in; }
+  uint64_t total_out() const { return lzma_stream_.total_out; }
+
+ protected:
+  int overflow(int ch) override {
+    if (!ok_) return EOF;
+    if (ch != EOF) {
+      *pptr() = static_cast<char>(ch);
+      pbump(1);
+    }
+    if (!flush_to_lzma(LZMA_RUN)) {
+      ok_ = false;
+      return EOF;
+    }
+    return ch;
+  }
+
+  int sync() override {
+    if (!ok_) return -1;
+    if (!flush_to_lzma(LZMA_RUN)) {
+      ok_ = false;
+      return -1;
+    }
+    return 0;
+  }
+
+ private:
+    static constexpr size_t kBufSize = 65535;
+
+  bool flush_to_lzma(lzma_action action) {
+    lzma_stream_.next_in = reinterpret_cast<const uint8_t*>(pbase());
+    lzma_stream_.avail_in = static_cast<size_t>(pptr() - pbase());
+
+    do {
+      uint8_t out_buf[kBufSize];
+      lzma_stream_.next_out = out_buf;
+      lzma_stream_.avail_out = kBufSize;
+
+      lzma_ret ret = lzma_code(&lzma_stream_, action);
+      if (ret != LZMA_OK && ret != LZMA_STREAM_END) return false;
+
+      size_t have = kBufSize - lzma_stream_.avail_out;
+      if (have > 0) {
+        dest_.write(reinterpret_cast<const char*>(out_buf), have);
+        if (!dest_) return false;
+      }
+
+      if (ret == LZMA_STREAM_END) break;
+    } while (lzma_stream_.avail_in > 0 || lzma_stream_.avail_out == 0);
+
+    setp(in_buf_, in_buf_ + kBufSize);
+    return true;
+  }
+
+  std::ostream& dest_;
+  lzma_stream lzma_stream_;
+  char in_buf_[kBufSize];
+  bool ok_;
+  bool finished_;
+};
+
+}  // namespace quokka
+
+#endif  // QUOKKA_LZMA_STREAMBUF_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ ida_target_link_libraries(
         absl::strings
         absl::str_format
         protobuf::libprotobuf
+        LibLZMA::LibLZMA
 )
 
 ida_install(TARGETS quokka_plugin

--- a/src/Quokka.cpp
+++ b/src/Quokka.cpp
@@ -208,28 +208,55 @@ static int ExportBinary(const std::string& filename) {
   }
 
   replace_wait_box("quokka: compressing & writing");
+  QLOG_INFO << "Compressing and writing the file...";
   std::string outfile = filename;
 
   std::fstream file(outfile,
                     std::ios::binary | std::ios::out | std::ios::trunc);
-  if (!file)
+  if (!file) {
+    QLOG_ERROR << absl::StrFormat("Failed to open file %s for writing",
+                                  outfile);
     return false;
+  }
 
   LzmaStreambuf lzma_buf(file);
   std::ostream lzma_out(&lzma_buf);
 
-  if (!quokka_protobuf.SerializeToOstream(&lzma_out))
-    return false;
+  if (!quokka_protobuf.SerializeToOstream(&lzma_out)) {
+    // Print internal state for debugging
+    QLOG_ERROR << "Failed to serialize protobuf to output stream";
+    QLOG_ERROR << absl::StrFormat(
+        "Stream state: good=%d, bad=%d, fail=%d, eof=%d", lzma_out.good(),
+        lzma_out.bad(), lzma_out.fail(), lzma_out.eof());
+    QLOG_ERROR << absl::StrFormat(
+        "Underlying file state: good=%d, bad=%d, fail=%d", file.good(),
+        file.bad(), file.fail());
 
-  if (!lzma_buf.finish())
-    return false;
+    // Check protobuf message size to see if it exceeds 2GB limit
+    size_t msg_size = quokka_protobuf.ByteSizeLong();
+    QLOG_INFO << absl::StrFormat("Protobuf message size: %.2f MB",
+                                 msg_size / (1024.0 * 1024.0));
+    if (msg_size > INT_MAX) {
+      QLOG_ERROR << "Protobuf message exceeds 2GB serialization limit";
+    }
 
-  QLOG_INFO << absl::StrFormat(
-      "Compressed %llu bytes -> %llu bytes (%.1f%%)", lzma_buf.total_in(),
-      lzma_buf.total_out(), 100.0 * lzma_buf.total_out() / lzma_buf.total_in());
+    return false;
+  }
+
+  if (!lzma_buf.finish()) {
+    QLOG_ERROR << "Failed to finalize LZMA stream";
+    return false;
+  }
+
+  uint64_t in_size = lzma_buf.total_in();
+  uint64_t out_size = lzma_buf.total_out();
+
+  QLOG_INFO << absl::StrFormat("Compressed %llu bytes -> %llu bytes (%.1f%%)",
+                               in_size, out_size,
+                               (100.0 * (in_size - out_size) / in_size));
 
   QLOG_INFO << absl::StrFormat("File %s is written", outfile);
-  QLOG_INFO << absl::StrFormat("quokka finished (took: %.2fs)",
+  QLOG_INFO << absl::StrFormat("quokka finished (took %.2fs)",
                                timer.ElapsedSeconds(absl::Now()));
 
   // Clean everything

--- a/src/Quokka.cpp
+++ b/src/Quokka.cpp
@@ -52,6 +52,7 @@
 #include "quokka/Function.h"
 #include "quokka/Layout.h"
 #include "quokka/Logger.h"
+#include "quokka/LzmaStreambuf.h"
 #include "quokka/ProtoWrapper.h"
 #include "quokka/Quokka.h"
 #include "quokka/Reference.h"
@@ -182,7 +183,8 @@ static int ExportBinary(const std::string& filename) {
   }
   auto [functions, ranges] = std::move(funcs_and_ranges);
 
-  // Export data types (after functions so decompiler-created types are captured)
+  // Export data types (after functions so decompiler-created types are
+  // captured)
   {
     SCOPED_BOX_STEP("quokka: exporting data types",
                     "Starting to export data types...",
@@ -205,20 +207,26 @@ static int ExportBinary(const std::string& filename) {
     WriteFunctions(&quokka_protobuf, std::move(functions));
   }
 
-  replace_wait_box("quokka: writing on the wire");
+  replace_wait_box("quokka: compressing & writing");
   std::string outfile = filename;
 
-  std::fstream stream(outfile,
-                      std::ios::binary | std::ios::out | std::ios::trunc);
-  if (!quokka_protobuf.SerializeToOstream(&stream)) {
-    QLOGE << "Unable to write the file, trying with a temp file.";
-    outfile = "/tmp/Exported.quokka";
-    stream = std::fstream(outfile,
-                          std::ios::binary | std::ios::out | std::ios::trunc);
-    if (!quokka_protobuf.SerializeToOstream(&stream)) {
-      QLOG_FATAL << "Unable to write to temp file as well";
-    }
-  }
+  std::fstream file(outfile,
+                    std::ios::binary | std::ios::out | std::ios::trunc);
+  if (!file)
+    return false;
+
+  LzmaStreambuf lzma_buf(file);
+  std::ostream lzma_out(&lzma_buf);
+
+  if (!quokka_protobuf.SerializeToOstream(&lzma_out))
+    return false;
+
+  if (!lzma_buf.finish())
+    return false;
+
+  QLOG_INFO << absl::StrFormat(
+      "Compressed %llu bytes -> %llu bytes (%.1f%%)", lzma_buf.total_in(),
+      lzma_buf.total_out(), 100.0 * lzma_buf.total_out() / lzma_buf.total_in());
 
   QLOG_INFO << absl::StrFormat("File %s is written", outfile);
   QLOG_INFO << absl::StrFormat("quokka finished (took: %.2fs)",


### PR DESCRIPTION
This MR explores reducing file size "at-rest" on disk, especially with the upcoming decompilation within quokka files.

Depending on the mode we currently have:

## Baselines

  Baseline          | elf-Linux-ARMv7-ls  | ls            | elf-Linux-x64-bash | sqlitebrowser   |
|-------------------|---------------------|---------------|--------------------|-----------------|
| BinSize           | 89K                 | 152K          | 905K               | 6.5M            |
| quokka (L)        | 69K      (x0.77)    | 107K (x0.7)   | 663K   (x0.73)     | 2.7M   (x0.41)  |
| quokka (N)        | 374K     (x4.20)    | 500K (x3.28)  | 3.1M   (x3.43)     | 14M    (x2.15)  |
| quokka (F)        | 452K     (x5)       | 592K (x3.89)  | 3.6M   (x3.98)     | 16M    (x2.46)  |

*(L: Light, N: Normal, F: Full )*

## Compression Algorithms

I experimented GZIP, LZMA(xz), and 7z compression algorithms. They provide the following result:

|  Compression Test  | elf-Linux-ARMv7-ls  | ls            | elf-Linux-x64-bash | sqlitebrowser   |
|-------------------|---------------------|---------------|--------------------|-----------------|
| quokka (N)        | 374K                | 500K          | 3.1M               | 14M             |
| quokka (N) gz     | 128K     (x0.34)    | 169K  (x0.34) | 1.1M   (x0.35)     | 4.1M   (x0.29)  |
| quokka (N) xz     | 104K     (x0.28)    | 137K  (x0.28) | 848K   (x0.28)     | 3.1M   (x0.22)  |
| quokka (N) 7z     | 103K     (x0.28)    | 137K  (x0.28) | 848K   (x0.28)     | 3.1M   (x0.22)  |

The compression range from ~60% to 80% which has a **huge** positive impact on the resulting size.

When also *integrating decompilation* we obtain the following results:

|  Decompilation Test| elf-Linux-ARMv7-ls  | ls            | elf-Linux-x64-bash | sqlitebrowser   |
|-------------------|---------------------|---------------|--------------------|-----------------|
| quokka (N)        | 374K                | 500K          | 3.1M               | 14M             |
| quokka-dec (N)    | 677K     (x1.81)    | 891K  (x1.78) | 5.4M   (x1.74)     | 25M    (x1.79)  |
| quokka-dec (N) gz | 191K     (x0.51)    | 249K  (x0.50) | 1.5M   (x0.48)     | 5.9M   (x0.42)  |
| quokka-dec (N) xz | 155K     (x0.41)    | 200K  (x0.40) | 1.2M   (x0.39)     | 4.2M   (x0.30)  |
| quokka-dec (N) 7z | 154K     (x0.41)    | 199K  (x0.40) | 1.2M   (x0.39)     | 4.2M   (x0.30)  |

*((xN) is the size inflation factor compared to the original)*

As one can see compression, completely mitigates the size inflation. E.g: from a 25Mb quokka file we shrink to 4.2M once compressed which is x3 smaller than the quokka without decompilation inside !

## Time overhead

I selected `xz` which seems the most efficient and supported natively in Python and through `liblzma-dev` for C, C++.
Rough time impact is the following (tried only once per target):

|    Export Time       | elf-Linux-ARMv7-ls  | ls            | elf-Linux-x64-bash | sqlitebrowser   |
|-----------------------|---------------------|---------------|--------------------|-----------------|
|  quokka     | 0.12s               | 0.12s         | 0.79s              | 4.53s           |
|    quokka-xz  | 0.22s  (+83%)       | 0.26s (+53%)  | 1.63s  (+51%)      | 8.74s (+48%)    |

|   Load Time       | elf-Linux-ARMv7-ls  | ls            | elf-Linux-x64-bash | sqlitebrowser   |
|-----------------------|---------------------|---------------|--------------------|-----------------|
| quokka     | 72.8ms              | 86.1ms        | 343ms              | 1.56s           |
| quokka-xz  | 49.6ms              | 76.3ms        | 399ms              | 1.55s           |

*(performed on .i64 already disassembled)*

We can observe a ~50% slow-down during export, which tends to reduce as the binary grow bigger.
The loading time in Python does not seems to be impacted.


## The Merge Request

The  code systematically compress the resulting protobuf on disk. Whether leaving it as an optional option is an open question. The retro-compatibility is kept as loading in Python first try loading it as an LZMA file and if fails opens it as a plain-text protobuf file.