### PR TITLE
Add TypedefType support, type system improvements, and CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -17,4 +19,6 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
 
   warm-cache:
     name: Warm dependency cache (${{ matrix.os }})
+    if: github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -143,6 +144,7 @@ jobs:
   cpp-tests:
     name: C++ standalone tests (${{ matrix.os }})
     needs: [warm-cache]
+    if: ${{ !failure() && !cancelled() }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -229,6 +231,7 @@ jobs:
 
   build:
     needs: [setup, warm-cache]
+    if: ${{ !failure() && !cancelled() }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,18 @@ on:
       - "*"
   pull_request:
     branches: ["**"]
+    paths:
+      - "src/**"
+      - "include/**"
+      - "CMakeLists.txt"
+      - "cmake/**"
+      - "proto/**"
+      - "tests/cpp/**"
+      - "scripts/**"
+      - "third_party/ida-sdk/**"
+      - "sdk_lockfile"
+      - ".gitmodules"
+      - ".github/workflows/build.yml"
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,12 +452,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         ida_sdk: [74, 77, 80, 81, 82, 83, 84, 85, 90, 90sp1, 91, 9.2, 9.3]
         bitness: ["", "-32"]
         include:
-          - os: windows-latest
-            ext: dll
           - os: ubuntu-latest
             ext: so
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,6 @@ jobs:
           persist-credentials: false
 
       # Check caches before installing any tools to skip setup on hit
-      # zizmor: ignore[cache-poisoning] -- warm-cache only runs on push (not PRs)
       - name: Cache FetchContent dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
@@ -94,7 +93,6 @@ jobs:
           restore-keys: |
             fetchcontent-${{ runner.os }}-
 
-      # zizmor: ignore[cache-poisoning] -- warm-cache only runs on push (not PRs)
       - name: Cache ccache
         id: ccache-cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,7 @@ jobs:
           persist-credentials: false
 
       # Check caches before installing any tools to skip setup on hit
+      # zizmor: ignore[cache-poisoning] -- warm-cache only runs on push (not PRs)
       - name: Cache FetchContent dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
@@ -93,6 +94,7 @@ jobs:
           restore-keys: |
             fetchcontent-${{ runner.os }}-
 
+      # zizmor: ignore[cache-poisoning] -- warm-cache only runs on push (not PRs)
       - name: Cache ccache
         id: ccache-cache
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -200,16 +202,16 @@ jobs:
           echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           echo "FETCHCONTENT_BASE_DIR=$HOME/.fetchcontent" >> $GITHUB_ENV
 
-      - name: Cache FetchContent dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Restore FetchContent cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.fetchcontent
           key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
             fetchcontent-${{ runner.os }}-
 
-      - name: Cache ccache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Restore ccache cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.ccache
           key: ccache-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
@@ -273,7 +275,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set IDA SDK password
-        if: ${{ contains('74,77,80,81,82,83,84,85,90,90sp1,91', matrix.ida_sdk) }}
+        if: ${{ contains(fromJSON('["74","77","80","81","82","83","84","85","90","90sp1","91"]'), matrix.ida_sdk) }}
         env:
           IDA_SDK: ${{ matrix.ida_sdk }}
         shell: bash
@@ -339,16 +341,16 @@ jobs:
           echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
           echo "FETCHCONTENT_BASE_DIR=$HOME/.fetchcontent" >> $GITHUB_ENV
 
-      - name: Cache FetchContent dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Restore FetchContent cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.fetchcontent
           key: fetchcontent-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
             fetchcontent-${{ runner.os }}-
 
-      - name: Cache ccache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - name: Restore ccache cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.ccache
           key: ccache-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
@@ -362,10 +364,10 @@ jobs:
           ccache --set-config=compression=true
           ccache -z
 
-      - name: Cache IDA SDK
-        if: ${{ contains('74,77,80,81,82,83,84,85,90,90sp1,91', matrix.ida_sdk) }}
+      - name: Restore IDA SDK cache
+        if: ${{ contains(fromJSON('["74","77","80","81","82","83","84","85","90","90sp1","91"]'), matrix.ida_sdk) }}
         id: cache-sdk
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: third_party/idasdk${{ matrix.ida_sdk }}
           key: idasdk-${{ runner.os }}-${{ matrix.ida_sdk }}-${{ hashFiles('sdk_lockfile') }}
@@ -373,7 +375,7 @@ jobs:
       - name: Fetch IDA SDK (Linux / MacOS)
         if:
           ${{ steps.cache-sdk.outputs.cache-hit != 'true' &&
-          contains('74,77,80,81,82,83,84,85,90,90sp1,91', matrix.ida_sdk) &&
+          contains(fromJSON('["74","77","80","81","82","83","84","85","90","90sp1","91"]'), matrix.ida_sdk) &&
           (matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest') }}
         env:
           IDA_SDK: ${{ matrix.ida_sdk }}
@@ -388,7 +390,7 @@ jobs:
       - name: Fetch IDA SDK (Windows)
         if:
           ${{ steps.cache-sdk.outputs.cache-hit != 'true' &&
-          contains('74,77,80,81,82,83,84,85,90,90sp1,91', matrix.ida_sdk) &&
+          contains(fromJSON('["74","77","80","81","82","83","84","85","90","90sp1","91"]'), matrix.ida_sdk) &&
           matrix.os == 'windows-latest' }}
         env:
           IDA_SDK: ${{ matrix.ida_sdk }}
@@ -399,6 +401,13 @@ jobs:
           cd ..
           7z.exe x -p"${env:IDA_SDK_PASSWORD}" -y -o"third_party" "third_party\${env:IDA_SDK_VERSION}.zip"
           rm "third_party\${env:IDA_SDK_VERSION}\include\regex.h"
+
+      - name: Save IDA SDK cache
+        if: ${{ steps.cache-sdk.outputs.cache-hit != 'true' && contains(fromJSON('["74","77","80","81","82","83","84","85","90","90sp1","91"]'), matrix.ida_sdk) }}
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: third_party/idasdk${{ matrix.ida_sdk }}
+          key: idasdk-${{ runner.os }}-${{ matrix.ida_sdk }}-${{ hashFiles('sdk_lockfile') }}
 
       - name: Prepare build environment (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -467,7 +476,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Artifacts (32)
-        if: ${{ contains('74,77,80,81,82,83,84', matrix.ida_sdk) }}
+        if: ${{ contains(fromJSON('["74","77","80","81","82","83","84"]'), matrix.ida_sdk) }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: idaplugin-${{ matrix.os }}-${{ matrix.ida_sdk }}-32

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: quokka-build
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  pull_request:
+    branches: ["**"]
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,29 +84,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
-        with:
-          cmake-version: "latest"
-
-      - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
-
-      - name: Install ccache
-        shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install ccache
-          else
-            sudo apt-get update && sudo apt-get install -y ccache
-          fi
-
-      - name: Set up build caching
-        shell: bash
-        run: |
-          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
-          echo "FETCHCONTENT_BASE_DIR=$HOME/.fetchcontent" >> $GITHUB_ENV
-
+      # Check caches before installing any tools to skip setup on hit
       - name: Cache FetchContent dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
@@ -123,6 +101,34 @@ jobs:
           key: ccache-${{ runner.os }}-${{ hashFiles('CMakeLists.txt') }}
           restore-keys: |
             ccache-${{ runner.os }}-
+
+      # Everything below only runs on cache miss
+      - name: Setup cmake
+        if: steps.ccache-cache.outputs.cache-hit != 'true'
+        uses: jwlawson/actions-setup-cmake@3a6cbe35ba64df7ca70c51365c4aff65db9a9037 # v2.1.1
+        with:
+          cmake-version: "latest"
+
+      - name: Install Ninja
+        if: steps.ccache-cache.outputs.cache-hit != 'true'
+        uses: seanmiddleditch/gha-setup-ninja@3b1f8f94a2f8254bd26914c4ab9474d4f0015f67 # v6
+
+      - name: Install ccache
+        if: steps.ccache-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install ccache
+          else
+            sudo apt-get update && sudo apt-get install -y ccache
+          fi
+
+      - name: Set up build caching
+        if: steps.ccache-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+          echo "FETCHCONTENT_BASE_DIR=$HOME/.fetchcontent" >> $GITHUB_ENV
 
       - name: Configure ccache
         if: steps.ccache-cache.outputs.cache-hit != 'true'
@@ -153,7 +159,7 @@ jobs:
         run: cmake --build build-deps --config $BUILD_TYPE
 
       - name: Show ccache stats
-        if: always()
+        if: ${{ always() && steps.ccache-cache.outputs.cache-hit != 'true' }}
         shell: bash
         run: ccache -sv || true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ on:
       - ".gitmodules"
       - ".github/workflows/build.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: Release
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,6 +3,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - "bindings/python/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "setup.py"
+      - "doxygen.cfg"
+      - "README.md"
+      - ".github/workflows/doc.yml"
 
 permissions: {}
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,6 @@ jobs:
       pages: write
       id-token: write
     steps:
-      # zizmor: ignore[artipacked] -- mkdocs gh-deploy needs credentials to push to gh-pages
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,7 @@ jobs:
       pages: write
       id-token: write
     steps:
+      # zizmor: ignore[artipacked] -- mkdocs gh-deploy needs credentials to push to gh-pages
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,6 +13,10 @@ on:
       - "README.md"
       - ".github/workflows/doc.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ghidra.yml
+++ b/.github/workflows/ghidra.yml
@@ -17,6 +17,10 @@ on:
       - ".gitmodules"
       - ".github/workflows/ghidra.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/ghidra.yml
+++ b/.github/workflows/ghidra.yml
@@ -29,10 +29,6 @@ jobs:
         unzip -q ghidra.zip -d /opt
         echo "GHIDRA_INSTALL_DIR=/opt/ghidra_12.0.3_PUBLIC" >> $GITHUB_ENV
 
-    - name: Build extension
+    - name: Build and test extension
       working-directory: ghidra_extension
       run: gradle build
-
-    - name: Run tests
-      working-directory: ghidra_extension
-      run: gradle test

--- a/.github/workflows/ghidra.yml
+++ b/.github/workflows/ghidra.yml
@@ -37,11 +37,21 @@ jobs:
         distribution: temurin
         java-version: '21'
 
+    - name: Cache Ghidra installation
+      id: ghidra-cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: /opt/ghidra_12.0.3_PUBLIC
+        key: ghidra-12.0.3-PUBLIC-20260210
+
     - name: Download Ghidra 12.0.3
+      if: steps.ghidra-cache.outputs.cache-hit != 'true'
       run: |
         wget -q https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_12.0.3_build/ghidra_12.0.3_PUBLIC_20260210.zip -O ghidra.zip
         unzip -q ghidra.zip -d /opt
-        echo "GHIDRA_INSTALL_DIR=/opt/ghidra_12.0.3_PUBLIC" >> $GITHUB_ENV
+
+    - name: Set Ghidra environment
+      run: echo "GHIDRA_INSTALL_DIR=/opt/ghidra_12.0.3_PUBLIC" >> $GITHUB_ENV
 
     - name: Build and test extension
       working-directory: ghidra_extension

--- a/.github/workflows/ghidra.yml
+++ b/.github/workflows/ghidra.yml
@@ -4,8 +4,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "ghidra_extension/**"
+      - "proto/**"
+      - ".gitmodules"
+      - ".github/workflows/ghidra.yml"
   pull_request:
     branches: ["**"]
+    paths:
+      - "ghidra_extension/**"
+      - "proto/**"
+      - ".gitmodules"
+      - ".github/workflows/ghidra.yml"
 
 permissions: {}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,6 +23,10 @@ on:
       - "MANIFEST.in"
       - ".github/workflows/python.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -31,8 +31,13 @@ permissions: {}
 
 jobs:
   python-test:
-    name: "Python package test"
-    runs-on: ubuntu-latest
+    name: "Python ${{ matrix.python-version }} / ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -40,7 +45,7 @@ jobs:
         lfs: true
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: '3.10'
+        python-version: ${{ matrix.python-version }}
     - run: pip install '.[test]'
     - name: Tests
       run: pytest tests/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,6 +46,9 @@ jobs:
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install libmagic (macOS)
+      if: runner.os == 'macOS'
+      run: brew install libmagic
     - run: pip install '.[test]'
     - name: Tests
       run: pytest tests/python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,8 +4,24 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "bindings/python/**"
+      - "proto/**"
+      - "tests/python/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".github/workflows/python.yml"
   pull_request:
     branches: ["**"]
+    paths:
+      - "bindings/python/**"
+      - "proto/**"
+      - "tests/python/**"
+      - "pyproject.toml"
+      - "setup.py"
+      - "MANIFEST.in"
+      - ".github/workflows/python.yml"
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -3,8 +3,12 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 on:
   push:
     branches: ["main"]
+    paths:
+      - ".github/workflows/**"
   pull_request:
     branches: ["**"]
+    paths:
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - ".github/workflows/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # warm-cache job only runs on push (not PRs), so cache poisoning is not a risk
+      - build.yml:89
+      - build.yml:98
+  artipacked:
+    ignore:
+      # mkdocs gh-deploy needs credentials to push to gh-pages
+      - doc.yml:30

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ ghidra_extension/dist/
 *.id2
 *.nam
 *.til
+*.i64

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Table of Contents
 ## Introduction
 
 Quokka is a binary exporter: from the disassembly of a program, it generates
-an export file that can be used without the disassembler.
+an export file that can be used without the disassembler. It currently supports
+**IDA Pro** and **Ghidra** as disassembly backends.
 
 The main objective of **Quokka** is to enable to completely manipulate the
 binary without ever opening a disassembler after the initial export. Moreover, it
@@ -73,6 +74,15 @@ The plugin is built on the CI and available in the
 
 To download the plugin, get the file named `quokka_plugin**.so`.
 
+### Ghidra Extension
+
+Quokka also supports exporting from **Ghidra** (>= 12.0.3) via a dedicated
+extension. It produces the same `.quokka` protobuf files that the Python
+library can load.
+
+For build instructions, installation, and usage details see the
+[Ghidra extension README](ghidra_extension/README.md).
+
 ## Usage
 
 ### Exporting via GUI
@@ -92,12 +102,12 @@ in binding)*
 
 ### Exporting in headless
 
+#### IDA
+
 !!! note
 
     This requires a working IDA installation.
 
-
-- Either using command line:
 ```commandline
 $ idat -OQuokkaAuto:true -OQuokkaDecompiled:true -A /path/to/hello.i64
 ```
@@ -106,6 +116,18 @@ All available options are described in the [Usage](https://quarkslab.github.io/q
 
 Note: `idat` is used instead of `ida` to increase the export speed as graphical interface
 is not needed.
+
+#### Ghidra
+
+```commandline
+$ analyzeHeadless /tmp/proj Test \
+    -import /path/to/binary \
+    -scriptPath ghidra_extension/src/script/ghidra_scripts \
+    -postScript QuokkaExportHeadless.java \
+    --out=/path/to/output.quokka --mode=LIGHT
+```
+
+See the [Ghidra extension README](ghidra_extension/README.md) for more details.
 
 ### Exporting in CLI
 

--- a/bindings/python/quokka/__init__.py
+++ b/bindings/python/quokka/__init__.py
@@ -59,6 +59,7 @@ from quokka.data_type import (
     UnionType,
     StructureType,
     StructureTypeMember,
+    TypedefType,
     TypeT
 )
 
@@ -87,6 +88,7 @@ __all__ = [
     "UnionType",
     "StructureType",
     "StructureTypeMember",
+    "TypedefType",
     "TypeT",
     # From exc.py
     "QuokkaError",

--- a/bindings/python/quokka/backends/ida.py
+++ b/bindings/python/quokka/backends/ida.py
@@ -5,6 +5,7 @@ import ida_funcs
 import ida_xref
 
 from quokka import Program
+from quokka.data_type import ComplexType
 
 
 
@@ -89,4 +90,50 @@ def apply_quokka(program: Program) -> int:
                 errors_count += 1
             print(f"[{res}] set comment of data at 0x{data.address:x}")
 
+    errors_count += apply_types(program)
+
     return errors_count
+
+
+def apply_types(program: Program) -> int:
+    """Apply new user-defined types to the IDA database.
+
+    Only types with ``is_new == True`` are created.  All types are registered
+    into the current TIL via ``parse_decls`` using their ``c_str`` (C
+    declaration).
+
+    Returns:
+        The number of errors encountered.
+    """
+    errors_count = 0
+
+    for typ in program.types:
+        if not isinstance(typ, ComplexType) or not typ.is_new:
+            continue
+
+        errors_count += _apply_type(typ)
+
+    return errors_count
+
+
+def _apply_type(typ: ComplexType) -> int:
+    """Register a single new type into the current TIL via ``parse_decls``.
+
+    Requires a non-empty ``c_str`` on the type.
+
+    Returns:
+        The error count (0 or 1).
+    """
+    kind = type(typ).__name__
+
+    if not typ.c_str:
+        print(f"[x] create {kind} {typ.name} (no c_str available)")
+        return 1
+
+    til = ida_typeinf.get_idati()
+    if ida_typeinf.parse_decls(til, typ.c_str, None, ida_typeinf.HTI_DCL) == 0:
+        print(f"[+] create {kind} {typ.name}")
+        return 0
+
+    print(f"[x] create {kind} {typ.name}")
+    return 1

--- a/bindings/python/quokka/data_type.py
+++ b/bindings/python/quokka/data_type.py
@@ -127,10 +127,12 @@ class BaseType(CoreType, IntEnum, metaclass=EnumABCMeta):
 
 
 class ComplexType(CoreType):
-    def __init__(self, proto_index: Index, proto: Pb.CompositeType|Pb.EnumType, program: "Program"):
+    def __init__(self, proto_index: Index, proto: Pb.CompositeType|Pb.EnumType, program: "Program",
+                 is_new: bool = False):
         self.type_index = proto_index
         self.proto = proto
         self._program = program
+        self.is_new: bool = is_new
 
         self.name: str = proto.name
         # type is not used here
@@ -220,10 +222,11 @@ class EnumTypeMember(CoreType):
 
 class EnumType(ComplexType):
     """Base class for all enums in quokka"""
-    
-    def __init__(self, index: Index, proto: Pb.EnumType, program: "Program") -> None:
+
+    def __init__(self, index: Index, proto: Pb.EnumType, program: "Program",
+                 is_new: bool = False) -> None:
         """Create an enum from a protobuf enum value"""
-        super().__init__(index, proto, program)
+        super().__init__(index, proto, program, is_new=is_new)
         self.name = proto.name
         self._members: dict[str, EnumTypeMember] = {member.name: EnumTypeMember(member, self) 
                                                     for member in proto.values}
@@ -270,9 +273,10 @@ class ArrayType(ComplexType):
         size: Type size (if known)
         c_str: C declaration of the type
     """
-    def __init__(self, index: Index, proto: Pb.CompositeType, program: "Program") -> None:
+    def __init__(self, index: Index, proto: Pb.CompositeType, program: "Program",
+                 is_new: bool = False) -> None:
         """Constructor"""
-        super().__init__(index, proto, program)
+        super().__init__(index, proto, program, is_new=is_new)
     
     @property
     def array_size(self) -> int:
@@ -299,9 +303,10 @@ class PointerType(ComplexType):
         size: Type size (if known)
         c_str: C declaration of the type
     """
-    def __init__(self, index: Index, proto: Pb.CompositeType, program: "Program") -> None:
+    def __init__(self, index: Index, proto: Pb.CompositeType, program: "Program",
+                 is_new: bool = False) -> None:
         """Constructor"""
-        super().__init__(index, proto, program)
+        super().__init__(index, proto, program, is_new=is_new)
     
     @property
     def pointed_type(self) -> 'TypeT':
@@ -326,9 +331,9 @@ class TypedefType(ComplexType):
     """
 
     def __init__(self, index: Index, proto: Pb.CompositeType,
-                 program: "Program") -> None:
+                 program: "Program", is_new: bool = False) -> None:
         """Constructor"""
-        super().__init__(index, proto, program)
+        super().__init__(index, proto, program, is_new=is_new)
 
     @property
     def aliased_type(self) -> 'TypeT':
@@ -423,10 +428,11 @@ class StructureType(dict, ComplexType):
         comments: Structure comments
     """
 
-    def __init__(self, index: Index, proto: "Pb.CompositeType", program: "Program") -> None:
+    def __init__(self, index: Index, proto: "Pb.CompositeType", program: "Program",
+                 is_new: bool = False) -> None:
         """Constructor"""
         dict.__init__(self)
-        ComplexType.__init__(self, index, proto, program)
+        ComplexType.__init__(self, index, proto, program, is_new=is_new)
 
         self._members_list: list[StructureTypeMember] = []
         for member in proto.members:
@@ -463,9 +469,10 @@ class UnionType(StructureType):
         program: Program back reference
     """
 
-    def __init__(self, index: Index, proto: "Pb.CompositeType", program: "Program") -> None:
+    def __init__(self, index: Index, proto: "Pb.CompositeType", program: "Program",
+                 is_new: bool = False) -> None:
         dict.__init__(self)
-        ComplexType.__init__(self, index, proto, program)
+        ComplexType.__init__(self, index, proto, program, is_new=is_new)
 
         self._members_list: list[StructureTypeMember] = []
         self.index_to_offset: dict[int, int] = {}

--- a/bindings/python/quokka/data_type.py
+++ b/bindings/python/quokka/data_type.py
@@ -51,6 +51,11 @@ class CoreType(ABC):
         return isinstance(self, PointerType)
 
     @property
+    def is_typedef(self) -> bool:
+        """Return True if this type is a typedef"""
+        return isinstance(self, TypedefType)
+
+    @property
     def is_composite(self) -> bool:
         """Return True if this type is a composite type (struct, union, array, pointer)"""
         return isinstance(self, ComplexType)
@@ -307,6 +312,40 @@ class PointerType(ComplexType):
         return f"<TPtr: {self.name}->{self.pointed_type}*>"
 
 
+class TypedefType(ComplexType):
+    """Typedef/alias type
+
+    Arguments:
+        proto: Protobuf data
+        program: Back reference to the program
+
+    Attributes:
+        name: Typedef name (e.g. 'DWORD', 'size_t')
+        size: Size of the aliased type in bytes
+        c_str: C declaration (e.g. 'typedef int DWORD;')
+    """
+
+    def __init__(self, index: Index, proto: Pb.CompositeType,
+                 program: "Program") -> None:
+        """Constructor"""
+        super().__init__(index, proto, program)
+
+    @property
+    def aliased_type(self) -> 'TypeT':
+        """Return the type this typedef aliases (single-step)"""
+        return self._program.get_type(self.proto.element_type_idx)
+
+    def resolve(self) -> 'TypeT':
+        """Recursively resolve through typedef chains to the concrete type"""
+        t = self.aliased_type
+        while isinstance(t, TypedefType):
+            t = t.aliased_type
+        return t
+
+    def __str__(self) -> str:
+        return f"<TTypedef: {self.name} -> {self.aliased_type}>"
+
+
 class StructureTypeMember(CoreType):
     """StructureMember
 
@@ -440,6 +479,6 @@ class UnionType(StructureType):
         return f"<TUnion: {self.name}>"
 
 
-TypeT = StructureType | BaseType | UnionType | ArrayType | PointerType | EnumType
+TypeT = StructureType | BaseType | UnionType | ArrayType | PointerType | EnumType | TypedefType
 TypeReference = TypeT | StructureTypeMember | EnumTypeMember
 TypeValue = int | float | str | bytes | EnumType  # and later we can add struct instances, arrays, etc.

--- a/bindings/python/quokka/program.py
+++ b/bindings/python/quokka/program.py
@@ -364,20 +364,21 @@ class Program(dict):
                 raise KeyError(f"No type with index {type_index}")
             
             pb_type = self.proto.types[type_index]
+            is_new = pb_type.is_new
             if pb_type.WhichOneof("OneofType") == "enum_type":
-                self._types[type_index] = EnumType(type_index, pb_type.enum_type, self)
+                self._types[type_index] = EnumType(type_index, pb_type.enum_type, self, is_new=is_new)
             elif pb_type.WhichOneof("OneofType") == "composite_type":
                 match pb_type.composite_type.type:
                     case Pb.CompositeType.CompositeSubType.TYPE_STRUCT:
-                        self._types[type_index] = StructureType(type_index, pb_type.composite_type, self)
+                        self._types[type_index] = StructureType(type_index, pb_type.composite_type, self, is_new=is_new)
                     case Pb.CompositeType.CompositeSubType.TYPE_UNION:
-                        self._types[type_index] = UnionType(type_index, pb_type.composite_type, self)
+                        self._types[type_index] = UnionType(type_index, pb_type.composite_type, self, is_new=is_new)
                     case Pb.CompositeType.CompositeSubType.TYPE_ARRAY:
-                        self._types[type_index] = ArrayType(type_index, pb_type.composite_type, self)
+                        self._types[type_index] = ArrayType(type_index, pb_type.composite_type, self, is_new=is_new)
                     case Pb.CompositeType.CompositeSubType.TYPE_POINTER:
-                        self._types[type_index] = PointerType(type_index, pb_type.composite_type, self)
+                        self._types[type_index] = PointerType(type_index, pb_type.composite_type, self, is_new=is_new)
                     case Pb.CompositeType.CompositeSubType.TYPE_TYPEDEF:
-                        self._types[type_index] = TypedefType(type_index, pb_type.composite_type, self)
+                        self._types[type_index] = TypedefType(type_index, pb_type.composite_type, self, is_new=is_new)
                     case _:
                         # Unknown CompositeSubType -- degrade to TYPE_UNK for forward compat
                         self._types[type_index] = BaseType.UNKNOWN

--- a/bindings/python/quokka/program.py
+++ b/bindings/python/quokka/program.py
@@ -42,6 +42,7 @@ from quokka.data_type import (
     PointerType,
     StructureType,
     EnumType,
+    TypedefType,
     TypeReference,
     UnionType,
     TypeT
@@ -375,6 +376,8 @@ class Program(dict):
                         self._types[type_index] = ArrayType(type_index, pb_type.composite_type, self)
                     case Pb.CompositeType.CompositeSubType.TYPE_POINTER:
                         self._types[type_index] = PointerType(type_index, pb_type.composite_type, self)
+                    case Pb.CompositeType.CompositeSubType.TYPE_TYPEDEF:
+                        self._types[type_index] = TypedefType(type_index, pb_type.composite_type, self)
                     case _:
                         # Unknown CompositeSubType -- degrade to TYPE_UNK for forward compat
                         self._types[type_index] = BaseType.UNKNOWN
@@ -411,6 +414,18 @@ class Program(dict):
             return typ.type   # A member cannot point to another member, so it must be a direct reference to a type
         else:
             return typ
+
+    def get_type_resolved(self, type_index: Index) -> TypeT:
+        """Get a type by index, resolving through any typedef chains.
+
+        This is equivalent to calling get_type() and then resolve() on the
+        result if it is a TypedefType. Useful for consumers that do not care
+        about typedef names and want the concrete type directly.
+        """
+        t = self.get_type(type_index)
+        while isinstance(t, TypedefType):
+            t = t.aliased_type
+        return t
 
     # @cached_property
     # def memory(self) -> "quokka.Memory":

--- a/proto/quokka.proto
+++ b/proto/quokka.proto
@@ -425,6 +425,9 @@ message Quokka {
       CompositeType composite_type = 2;
       BaseType primitive_type = 3;
     }
+    // True when the type was user-added (not from original analysis) and must
+    // be applied back to the database.  Only meaningful for non-primitive types.
+    bool is_new = 4;
   }
 
   Meta meta = 1;

--- a/tests/dataset/many_types.c
+++ b/tests/dataset/many_types.c
@@ -1,0 +1,769 @@
+// many_types.c
+// C11/C23-only "common" types + decl patterns intended to stress type
+// importers/parsers.
+//
+// Compile with:
+// clang -std=c23 -g3 -gdwarf-4 -O0 -fno-omit-frame-pointer -fno-inline \
+//    -fno-inline-functions -fno-optimize-sibling-calls -fno-strict-aliasing \
+//    -fstandalone-debug -fno-limit-debug-info \
+//    -fno-eliminate-unused-debug-types -Wall -Wextra many_types.c \
+//    -o many_types_c
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <wchar.h>
+
+#ifndef ENTRYPOINT
+#define ENTRYPOINT main
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTR_PACKED __attribute__((packed))
+#define ATTR_ALIGNED(n) __attribute__((aligned(n)))
+#define ATTR_UNUSED __attribute__((unused))
+#define USED __attribute__((used))
+#define SECTION(name) __attribute__((section(name)))
+#else
+#define ATTR_PACKED
+#define ATTR_ALIGNED(n)
+#define ATTR_UNUSED
+#define USED
+#define SECTION(name)
+#endif
+
+#ifdef __cplusplus
+#define ZINIT \
+  {           \
+  }
+#else
+#define ZINIT {0}
+#endif
+
+// -----------------------------------------------------------------------------
+// Useful functions
+// -----------------------------------------------------------------------------
+
+static int op_add(int a, int b) { return a + b; }
+static int op_sub(int a, int b) { return a - b; }
+static int op_mul(int a, int b) { return a * b; }
+static int op_div_safe(int a, int b) { return b ? (a / b) : 0; }
+static int op_mod_safe(int a, int b) { return b ? (a % b) : 0; }
+static int op_xor(int a, int b) { return a ^ b; }
+static int op_and(int a, int b) { return a & b; }
+static int op_or(int a, int b) { return a | b; }
+static int op_shl_masked(int a, int b) { return a << (b & 7); }
+static int op_shr_masked(int a, int b) {
+  return (int)(((unsigned)a) >> (b & 7));
+}
+static int op_max(int a, int b) { return (a > b) ? a : b; }
+static int op_min(int a, int b) { return (a < b) ? a : b; }
+
+// -----------------------------------------------------------------------------
+// Original-ish types (C-compatible)
+// -----------------------------------------------------------------------------
+
+union E {
+  uint8_t a[4];
+  uint32_t b;
+};
+
+// NOTE: In C, no enum underlying type syntax. Keep values and let C++ wrap its
+// own.
+enum D { FIRST = 0, SECOND, THIRD };
+
+struct C_ {
+  bool a;
+};
+typedef struct C_ C;
+
+struct B {
+  int a;
+  struct {
+    int a;
+    int b;
+  } b;
+  union BB_ {
+    struct {
+      int a : 16;
+      int b : 16;
+    } a;
+    int b;
+  } c;
+};
+
+struct A {
+  uint8_t a;
+  char b;
+  unsigned char b1;
+  short c;
+  uint32_t d;
+  long long e;
+  float f;
+  int g : 7;
+  double h;
+  bool i;
+  char j[20];
+  uint16_t k[10];
+  struct B l;
+  C m;
+  enum D n;
+  C* o;
+  void*** p;
+};
+
+// -----------------------------------------------------------------------------
+// Extra stress: weird bitfields / aggregates / packing
+// -----------------------------------------------------------------------------
+
+struct BitfieldWeird_C {
+  signed int s1 : 1;
+  unsigned int u1 : 1;
+  unsigned int u31 : 31;
+  unsigned int : 0;  // alignment boundary
+  unsigned int : 3;  // unnamed field
+  bool b1 : 1;       // (C++-parse safe; valid C23 too)
+  long long ll3 : 3;
+  signed char sc7 : 7;
+  unsigned short us12 : 12;
+};
+
+#pragma pack(push, 1)
+struct ATTR_PACKED Packed1_C {
+  uint8_t a;
+  uint32_t b;
+  union {
+    uint16_t u16;
+    struct {
+      uint8_t x;
+      uint8_t y;
+    } s;
+  } u;
+#ifdef __clang__
+  uint8_t tail[];  // flexible array member
+#else
+  uint8_t tail[0];
+#endif
+};
+#pragma pack(pop)
+
+struct FAM {
+  uint8_t a;
+  uint16_t b;
+  uint32_t tail[];
+};
+
+struct ATTR_ALIGNED(32) Aligned32_C {
+  uint8_t pad;
+  uint64_t x;
+};
+
+union UWeird_C {
+  uint64_t u64;
+  double d;
+  struct {
+    uint32_t lo;
+    uint32_t hi;
+  } parts32;
+  struct {
+    uint16_t a;
+    uint16_t b;
+    uint16_t c;
+    uint16_t e;
+  } parts16;
+  uint8_t bytes[8];
+};
+
+struct HasAnonAgg_C {
+  int tag;
+  union {
+    struct {
+      int a;
+      int b;
+    } ab;
+    struct {
+      short c;
+      short d;
+      short e;
+      short f;
+    } cdef;
+    union UWeird_C uw;
+  } u;
+};
+
+// -----------------------------------------------------------------------------
+// Typedef chains + declarator spaghetti
+// -----------------------------------------------------------------------------
+
+typedef uint32_t U32;
+typedef U32* PU32;
+typedef const U32* PCU32;
+typedef PCU32* PPCU32;
+typedef const PPCU32* CPPCU32;
+
+typedef int (*Fn1_C)(int);
+typedef int (*Fn2_C)(int, ...);
+typedef void (*VoidFn_C)(void);
+
+typedef int (*FnArr3_C[3])(int);
+typedef int (*(*PtrToFnArr3_C)[3])(int);
+
+typedef int (*(*FnReturningPtrArr_C)(int))[4];
+typedef int (*FnTakesPtrToArr_C)(const int (*)[5]);
+
+// -----------------------------------------------------------------------------
+// Forward decl / self-ref / incomplete-pointer arrays
+// -----------------------------------------------------------------------------
+
+struct Incomplete_C;  // incomplete
+
+struct SelfRef_C {
+  struct SelfRef_C* next;
+  const struct SelfRef_C* const* chain;
+  struct Incomplete_C* ip;
+  struct Incomplete_C** ipp;
+  struct Incomplete_C* iarr[3];
+};
+
+// -----------------------------------------------------------------------------
+// Prototypes for helper impls (so we can use them in global initializers)
+// -----------------------------------------------------------------------------
+
+static int f_plain_c(int x);
+static int f_var_c(int x, ...);
+static void f_void_c(void);
+static int (*ret_ptrarr_c(int))[4];
+static int takes_ptr_to_arr_c(const int (*p)[5]);
+
+// -----------------------------------------------------------------------------
+// Global sinks (data) to keep everything "observable"
+// -----------------------------------------------------------------------------
+
+USED SECTION(".data") volatile uint64_t g_sink_u64_c = 0;
+USED SECTION(".data") volatile uint32_t g_sink_u32_c = 0;
+USED SECTION(".data") volatile uint8_t g_sink_u8_c = 0;
+USED SECTION(".data") volatile int g_sink_i_c = 0;
+
+// -----------------------------------------------------------------------------
+// Globals
+// -----------------------------------------------------------------------------
+
+uint32_t v1;
+uint64_t v2;
+char v3;
+uint8_t v4;
+int v5;
+float v6;
+double v7;
+int* v8;
+uint8_t**** v9;
+int v10[10];
+char v11[] = "asdasd";
+struct A v12;
+enum D v13;
+
+/* Single function pointers */
+int (*g_fp0)(int, int) = op_add;
+int (*const g_fp1_const)(int, int) = op_sub;
+int (*g_fp2)(int, int) = NULL;
+int (*const* g_p_to_const_fp1)(int,
+                               int) = &g_fp1_const;  /* pointer to const fp */
+int (*(*const g_const_p_to_fp0))(int, int) = &g_fp0; /* const pointer to fp */
+
+/* Arrays of function pointers */
+int (*g_arr_fp8[8])(int, int) = {
+    op_add, op_sub, op_mul, op_div_safe, op_mod_safe, NULL, op_xor, op_and,
+};
+
+int (*g_arr_fp8_alt[8])(int, int) = {
+    op_or, op_shl_masked, op_shr_masked, op_max, op_min, op_add, op_sub, op_mul,
+};
+
+/* weird section #1 */
+USED SECTION(".rodata.weird") int (*const g_arr_fp4_const[4])(int, int) = {
+    op_min,
+    op_max,
+    op_or,
+    op_and,
+};
+
+/* Arrays of arrays of function pointers */
+int (*g_mat_fp[3][4])(int, int) = {
+    {op_add, op_sub, op_mul, op_div_safe},
+    {op_mod_safe, op_xor, op_and, NULL},
+    {op_or, op_shl_masked, op_shr_masked, op_max},
+};
+
+int (*const g_mat_fp_const[2][3])(int, int) = {
+    {op_min, op_max, op_add},
+    {op_sub, op_mul, op_or},
+};
+
+/* Pointer to array of function pointers */
+int (*(*g_ptr_to_arr8)[8])(int, int) = &g_arr_fp8;
+int (*(*const g_const_ptr_to_arr8)[8])(int, int) = &g_arr_fp8_alt;
+
+/* Pointer to array of const function pointers (array elements are const
+ * pointers) */
+int (*const (*g_ptr_to_const_arr4)[4])(int, int) = &g_arr_fp4_const;
+int (*const (*const g_const_ptr_to_const_arr4)[4])(int, int) = &g_arr_fp4_const;
+
+/* Arrays of pointers to arrays of function pointers */
+int (*(*g_arr_of_ptr_to_arr4[3])[4])(int, int) = {
+    &g_mat_fp[0],
+    &g_mat_fp[1],
+    &g_mat_fp[2],
+};
+
+int (*(*const g_arr_of_const_ptr_to_arr4[2])[4])(int, int) = {
+    &g_mat_fp[2],
+    &g_mat_fp[0],
+};
+
+/* Pointer to a 2D array of function pointers */
+/* weird section #2 */
+USED SECTION(".data.fnptr.strange") int (*(*g_ptr_to_mat3x4)[3][4])(int, int) =
+    &g_mat_fp;
+int (*const (*g_ptr_to_const_mat2x3)[2][3])(int, int) = &g_mat_fp_const;
+
+/* Array of pointers to 2D arrays of function pointers */
+int (*(*g_arr_of_ptr_to_mat[2])[3][4])(int, int) = {
+    &g_mat_fp,
+    &g_mat_fp,
+};
+
+/* Pointer to (pointer to array[4] of function pointers) */
+int (*(**g_pp_to_arr4)[4])(int, int) = &g_arr_of_ptr_to_arr4[1];
+
+/* A few more mixed-const indirections */
+int (*const* const g_const_p_to_const_fp1)(int, int) = &g_fp1_const;
+int (*(*g_p_to_mut_fp2))(int, int) = &g_fp2;
+
+struct Packed1_C* g_packed_ptr_c;
+struct FAM g_normal_fam;
+struct Aligned32_C g_al32_c;
+struct BitfieldWeird_C g_bfw_c;
+struct HasAnonAgg_C g_haa_c;
+union UWeird_C g_uw_c;
+struct SelfRef_C g_self_c;
+
+Fn1_C g_fn1_c;
+Fn2_C g_fn2_c;
+FnArr3_C g_fnarr3_c;
+PtrToFnArr3_C g_ptr_to_fnarr3_c;
+FnReturningPtrArr_C g_fn_ret_ptrarr_c;
+FnTakesPtrToArr_C g_fn_takes_ptr_to_arr_c;
+
+CPPCU32 g_cppcu32_c;
+
+// -----------------------------------------------------------------------------
+// Typedef edge-cases (see src/CLAUDE.md#190-200)
+// Tests: chains, over primitives, over structs/unions/enums,
+//        over arrays, over pointers (to primitive, struct, array, pointer),
+//        typedef-over-typedef-array, typedef-over-typedef-pointer,
+//        arrays-of-typedef, pointers-to-typedef
+// -----------------------------------------------------------------------------
+
+// --- Typedef over primitive (info embedded in tif, use get_real_type) ---
+typedef int TdInt;
+typedef unsigned char TdByte;
+typedef float TdFloat;
+typedef double TdDouble;
+TdInt g_tdint = 42;
+TdByte g_tdbyte = 0xff;
+TdFloat g_tdfloat = 3.14f;
+TdDouble g_tddouble = 2.718;
+
+// --- Typedef chain over primitive (A -> B -> C, get_next_type_name) ---
+typedef TdInt TdInt2;
+typedef TdInt2 TdInt3;
+TdInt2 g_tdint2 = 100;
+TdInt3 g_tdint3 = 200;
+
+// --- Typedef over struct/union/enum ---
+typedef struct A TdStructA;
+typedef struct B TdStructB;
+typedef union E TdUnionE;
+typedef union UWeird_C TdUWeird;
+typedef enum D TdEnumD;
+TdStructA g_td_structa;
+TdStructB g_td_structb;
+TdUnionE g_td_unione;
+TdUWeird g_td_uweird;
+TdEnumD g_td_enumd = SECOND;
+
+// --- Typedef over array (tif.is_array(); array info embedded in typedef) ---
+typedef int TdIntArr5[5];
+typedef uint32_t TdU32Arr3[3];
+typedef char TdCharBuf[64];
+TdIntArr5 g_td_intarr5 = {10, 20, 30, 40, 50};
+TdU32Arr3 g_td_u32arr3 = {0xAA, 0xBB, 0xCC};
+TdCharBuf g_td_charbuf = "hello typedef array";
+
+// --- Typedef over array of typedef (typedef -> array -> typedef element) ---
+typedef TdInt TdIntArr4[4];
+typedef TdByte TdByteArr8[8];
+typedef TdStructA TdStructAArr2[2];
+typedef TdUnionE TdUnionEArr3[3];
+typedef TdEnumD TdEnumDArr3[3];
+TdIntArr4 g_td_intarr4 = {1, 2, 3, 4};
+TdByteArr8 g_td_bytearr8 = {0, 1, 2, 3, 4, 5, 6, 7};
+TdStructAArr2 g_td_structaarr2;
+TdUnionEArr3 g_td_unionearr3;
+TdEnumDArr3 g_td_enumdarr3 = {FIRST, SECOND, THIRD};
+
+// Typedef chain over array
+typedef TdIntArr5 TdIntArr5Alias;
+TdIntArr5Alias g_td_intarr5_alias = {5, 4, 3, 2, 1};
+
+// --- Typedef over pointer to primitive (tif.is_ptr(), pointed is primitive) ---
+typedef int* TdIntPtr;
+typedef const int* TdConstIntPtr;
+typedef float* TdFloatPtr;
+typedef double* TdDoublePtr;
+typedef bool* TdBoolPtr;
+TdIntPtr g_td_intptr = (int*)0;
+TdConstIntPtr g_td_constintptr = (const int*)0;
+TdFloatPtr g_td_floatptr = (float*)0;
+TdDoublePtr g_td_doubleptr = (double*)0;
+TdBoolPtr g_td_boolptr = (bool*)0;
+
+// --- Typedef over pointer to typedef (typedef -> ptr -> typedef target) ---
+typedef TdInt* TdTdIntPtr;
+typedef TdFloat* TdTdFloatPtr;
+typedef TdByte* TdTdBytePtr;
+typedef const TdInt* TdConstTdIntPtr;
+typedef TdInt** TdTdIntPtrPtr;
+TdTdIntPtr g_td_tdintptr = (TdInt*)0;
+TdTdFloatPtr g_td_tdfloatptr = (TdFloat*)0;
+TdTdBytePtr g_td_tdbyteptr = (TdByte*)0;
+TdConstTdIntPtr g_td_consttdintptr = (const TdInt*)0;
+TdTdIntPtrPtr g_td_tdintptrptr = (TdInt**)0;
+
+// Typedef over pointer to typedef struct/union/enum
+typedef TdStructA* TdStructAPtr;
+typedef const TdStructA* TdConstStructAPtr;
+typedef TdUnionE* TdUnionEPtr;
+typedef TdEnumD* TdEnumDPtr;
+TdStructAPtr g_td_structaptr = (TdStructA*)0;
+TdConstStructAPtr g_td_conststructaptr = (const TdStructA*)0;
+TdUnionEPtr g_td_unioneptr = (TdUnionE*)0;
+TdEnumDPtr g_td_enumdptr = (TdEnumD*)0;
+
+// --- Typedef over pointer to array ---
+typedef int (*TdPtrToIntArr4)[4];
+typedef uint32_t (*TdPtrToU32Arr3)[3];
+TdPtrToIntArr4 g_td_ptr_to_intarr4 = (int (*)[4])0;
+TdPtrToU32Arr3 g_td_ptr_to_u32arr3 = (uint32_t (*)[3])0;
+
+// Typedef over pointer to typedef-array
+typedef TdIntArr5* TdPtrToTdIntArr5;
+typedef TdIntArr4* TdPtrToTdIntArr4;
+TdPtrToTdIntArr5 g_td_ptr_to_tdintarr5 = (TdIntArr5*)0;
+TdPtrToTdIntArr4 g_td_ptr_to_tdintarr4 = (TdIntArr4*)0;
+
+// --- Typedef over pointer to pointer ---
+typedef int** TdIntPtrPtr;
+typedef int*** TdIntPtrPtrPtr;
+typedef const int* const* TdConstPtrConstInt;
+TdIntPtrPtr g_td_intptrptr = (int**)0;
+TdIntPtrPtrPtr g_td_intptrptrptr = (int***)0;
+TdConstPtrConstInt g_td_constptrconstint = (const int* const*)0;
+
+// Typedef over pointer to pointer to typedef
+typedef TdInt** TdTdIntPtrPtr2;
+typedef TdInt*** TdTdIntPtrPtrPtr;
+TdTdIntPtrPtr2 g_td_tdintptrptr2 = (TdInt**)0;
+TdTdIntPtrPtrPtr g_td_tdintptrptrptr = (TdInt***)0;
+
+// --- Typedef chain over pointer ---
+typedef TdIntPtr TdIntPtr2;
+typedef TdIntPtr2 TdIntPtr3;
+TdIntPtr2 g_td_intptr2 = (int*)0;
+TdIntPtr3 g_td_intptr3 = (int*)0;
+
+// --- Variables: arrays of typedef'd types ---
+TdInt g_arr_tdint[4] = {1, 2, 3, 4};
+TdStructA g_arr_tdstructa[2];
+TdUnionE g_arr_tdunione[3];
+TdEnumD g_arr_tdenumd[3] = {FIRST, SECOND, THIRD};
+TdIntPtr g_arr_tdintptr[4] = {(int*)0, (int*)0, (int*)0, (int*)0};
+TdTdIntPtr g_arr_tdtdintptr[2] = {(TdInt*)0, (TdInt*)0};
+
+// --- Variables: pointers to typedef'd types ---
+TdInt* g_ptr_tdint = (TdInt*)0;
+TdStructA* g_ptr_tdstructa = (TdStructA*)0;
+TdIntArr5* g_ptr_tdintarr5 = (TdIntArr5*)0;
+TdInt3* g_ptr_tdint3 = (TdInt3*)0;
+TdIntPtr* g_ptr_tdintptr = (TdIntPtr*)0;
+TdIntArr4* g_ptr_tdintarr4 = (TdIntArr4*)0;
+
+// "section zoo" globals to ensure IDA sees typed objects in ro/data/bss/text
+
+// rodata: const typed objects
+USED SECTION(".rodata") const enum D g_d_ro = THIRD;
+// union E initialized via first member a[4] (portable C/C++)
+USED SECTION(".rodata") const union E g_e_ro = {{0x44, 0x33, 0x22, 0x11}};
+USED SECTION(".rodata") const union UWeird_C g_uw_ro = {0xdeadbeefcafebabeULL};
+USED SECTION(".rodata") const struct HasAnonAgg_C g_haa_ro = {7, {{10, 20}}};
+
+// weird section: put *data* into .text (don't write to it!)
+USED SECTION(".text") const
+    struct BitfieldWeird_C g_bfw_text = {-1, 1, 0x7fffffffU, 1, 3, 63, 0xfff};
+
+// bss-ish: explicit custom bss section objects (uninitialized)
+USED SECTION(".bss.weird") struct A g_a_bss;
+USED SECTION(".bss.weird") struct B g_b_bss;
+USED SECTION(".bss.weird") C g_c_bss;
+USED SECTION(".bss.weird") union E g_e_bss;
+USED SECTION(".bss.weird") union UWeird_C g_uw_bss;
+USED SECTION(".bss.weird") struct HasAnonAgg_C g_haa_bss;
+USED SECTION(".bss.weird") struct SelfRef_C g_sr_bss;
+USED SECTION(".bss.weird") struct Incomplete_C* g_incomplete_ptr_bss;
+
+// data: explicit data section objects
+USED SECTION(".data.weird") struct A g_a_data = ZINIT;
+USED SECTION(".data.weird") struct BitfieldWeird_C g_bfw_data = ZINIT;
+USED SECTION(".data.weird") U32 g_u32_data = 0x12345678U;
+USED SECTION(".data.weird") PU32 g_pu32_data = &g_u32_data;
+USED SECTION(".data.weird") PCU32 g_pcu32_data = &g_u32_data;
+USED SECTION(".data.weird") PPCU32 g_ppcu32_data = (PPCU32)&g_pcu32_data;
+USED SECTION(".data.weird") CPPCU32 g_cppcu32_data = (CPPCU32)&g_ppcu32_data;
+
+// ensure VoidFn_C is used globally too
+USED SECTION(".data.weird") VoidFn_C g_voidfn_c = &f_void_c;
+
+// flexible-array "storage" wrapper to get a real global instance that embeds
+// Packed1_C
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-variable-sized-type-not-at-end"
+struct Packed1_C_Storage {
+  struct Packed1_C h;
+  uint8_t tail_storage[8];
+};
+#pragma clang diagnostic pop
+USED SECTION(".data.weird") struct Packed1_C_Storage g_packed_storage = ZINIT;
+
+// function-pointer typedefs used globally in various sections
+USED SECTION(".rodata") const Fn1_C g_fn1_ro = &f_plain_c;
+USED SECTION(".rodata") const Fn2_C g_fn2_ro = &f_var_c;
+USED SECTION(".rodata") const FnReturningPtrArr_C g_fnret_ro = &ret_ptrarr_c;
+USED SECTION(".rodata") const FnTakesPtrToArr_C g_fntake_ro =
+    &takes_ptr_to_arr_c;
+
+// -----------------------------------------------------------------------------
+// Helper impls
+// -----------------------------------------------------------------------------
+
+static int f_plain_c(int x) { return x + 1; }
+static int f_var_c(int x, ...) { return x ^ 0x1234; }
+static void f_void_c(void) { g_sink_i_c ^= 0x55; }
+
+static int (*ret_ptrarr_c(int))[4] {
+  static int arr[4] = {1, 2, 3, 4};
+  return &arr;
+}
+
+static int takes_ptr_to_arr_c(const int (*p)[5]) { return (*p)[0]; }
+
+// -----------------------------------------------------------------------------
+// Global-only "touch" routine (no locals): creates code->data xrefs heavily
+// -----------------------------------------------------------------------------
+
+static void touch_globals_c(void) {
+  // tie together sectioned pointers/objects
+  g_cppcu32_c = g_cppcu32_data;
+
+  // point packed pointer at storage-backed header
+  g_packed_ptr_c = &g_packed_storage.h;
+
+  // assign from rodata into writable globals
+  g_uw_c = g_uw_ro;
+  g_haa_c = g_haa_ro;
+
+  // set up self-ref structure in bss
+  g_sr_bss.next = &g_sr_bss;
+  g_sr_bss.chain = (const struct SelfRef_C* const*)&g_sr_bss.next;
+  g_sr_bss.ip = (struct Incomplete_C*)0;
+  g_sr_bss.ipp = (struct Incomplete_C**)0;
+  g_sr_bss.iarr[0] = (struct Incomplete_C*)0;
+  g_self_c = g_sr_bss;
+
+  // set random variables
+  g_normal_fam.a = 1;
+
+  // function pointers (globals) and calls through them => xrefs
+  g_fn1_c = g_fn1_ro;
+  g_fn2_c = g_fn2_ro;
+  g_fn_ret_ptrarr_c = g_fnret_ro;
+  g_fn_takes_ptr_to_arr_c = g_fntake_ro;
+
+  g_sink_i_c ^= g_fn1_c(10);
+  g_sink_i_c ^= g_fn2_c(20, 1, 2, 3);
+
+  // pointer-to-array param usage (avoid locals: use a global array)
+  static int g_five[5] = {1, 2, 3, 4, 5};
+  const int (*p5)[5] = (const int (*)[5]) & g_five;
+  g_sink_i_c ^= g_fn_takes_ptr_to_arr_c(p5);
+
+  // function returning pointer-to-array
+  int (*p4)[4] = g_fn_ret_ptrarr_c(0);
+  g_sink_i_c ^= (*p4)[0];
+
+  // tie original globals to sinks
+  v1 = g_sink_u32_c ^= (uint32_t)g_sink_i_c;
+  v2 = g_sink_u64_c ^= (uint64_t)v1;
+  v3 = (char)(g_sink_u8_c ^= (uint8_t)v1);
+  v4 = (uint8_t)g_sink_u8_c;
+  v5 = g_sink_i_c;
+  v6 = (float)v1;
+  v7 = (double)v2;
+  v8 = (int*)&v5;
+  v9 = (uint8_t****)0;
+  v10[0] = v5;
+  v13 = g_d_ro;
+
+  // populate some structured globals (writable)
+  g_al32_c.x = 0x1122334455667788ULL;
+  g_e_bss.b = 0xAABBCCDDu;
+  g_incomplete_ptr_bss = (struct Incomplete_C*)0;
+
+  // "use" the `.text` data by reading it (do not write!)
+  g_sink_u32_c ^= (uint32_t)g_bfw_text.us12;
+
+  /* Function pointers */
+  g_fp0 = op_mul;
+  g_fp2 = op_div_safe;
+  g_arr_fp8[5] = op_or;         /* was NULL */
+  g_arr_fp8[3] = op_shr_masked; /* replace div */
+  g_mat_fp[1][3] = op_min;      /* was NULL */
+  g_ptr_to_arr8 = &g_arr_fp8_alt;
+  g_arr_of_ptr_to_arr4[0] = &g_mat_fp[2];
+  g_arr_of_ptr_to_mat[1] = &g_mat_fp;
+
+  g_sink_u32_c += g_fp0(7, 3);               /* mul => 21 */
+  g_sink_u32_c += g_fp1_const(7, 3);         /* sub => 4  */
+  g_sink_u32_c += (*g_p_to_const_fp1)(7, 3); /* sub => 4  */
+  g_sink_u32_c += (*g_const_p_to_fp0)(8, 2); /* mul => 16 */
+  g_sink_u32_c += (*g_p_to_mut_fp2)(9, 2);   /* div => 4  */
+
+  g_sink_u32_c += g_arr_fp8[0](10, 5);                   /* add => 15 */
+  g_sink_u32_c += (*g_ptr_to_arr8)[1](3, 2);             /* shl => 12 */
+  g_sink_u32_c += (*g_const_ptr_to_arr8)[2](33, 1);      /* shr => 16 */
+  g_sink_u32_c += (*g_ptr_to_const_arr4)[0](9, 4);       /* min => 4  */
+  g_sink_u32_c += (*g_const_ptr_to_const_arr4)[1](9, 4); /* max => 9  */
+
+  g_sink_u32_c += g_mat_fp[0][2](6, 7);                 /* mul => 42 */
+  g_sink_u32_c += g_mat_fp[1][3](6, 7);                 /* min => 6  */
+  g_sink_u32_c += (*g_arr_of_ptr_to_arr4[0])[0](12, 3); /* row2[0]=or  => 15 */
+  g_sink_u32_c += (*g_arr_of_ptr_to_arr4[1])[1](12, 5); /* row1[1]=xor => 9  */
+  g_sink_u32_c +=
+      (*g_arr_of_const_ptr_to_arr4[0])[3](12, 5); /* row2[3]=max => 12 */
+  g_sink_u32_c += (*(*g_pp_to_arr4))[2](20, 6);   /* row1[2]=and => 4  */
+
+  g_sink_u32_c += (*g_ptr_to_mat3x4)[2][1](1, 3);         /* shl => 8  */
+  g_sink_u32_c += (*g_arr_of_ptr_to_mat[1])[0][3](22, 5); /* div => 4  */
+  g_sink_u32_c += (*g_ptr_to_const_mat2x3)[1][2](8, 3);   /* or => 11  */
+
+  /* Touch the extra mixed-const alias, too. */
+  g_sink_u32_c += (*g_const_p_to_const_fp1)(20, 1); /* sub => 19 */
+
+  /* Touch typedef edge-case globals so they survive optimization */
+  g_sink_i_c ^= g_tdint ^ g_tdbyte ^ g_tdint2 ^ g_tdint3;
+  g_sink_u32_c += (uint32_t)g_tdfloat;
+  g_sink_u64_c ^= (uint64_t)(g_tddouble * 1.0);
+  g_td_enumd = THIRD;
+  g_td_structa.a = (uint8_t)g_tdint;
+  g_td_structb.a = g_tdint2;
+  g_td_unione.b = 0xDEAD;
+  g_td_uweird.u64 = 0xCAFE;
+
+  g_td_intarr5[0] = g_tdint;
+  g_td_u32arr3[0] = (uint32_t)g_tdint2;
+  g_td_charbuf[0] = 'X';
+  g_td_intarr4[0] = g_tdint3;
+  g_td_bytearr8[0] = g_tdbyte;
+  g_td_structaarr2[0].a = 1;
+  g_td_unionearr3[0].b = 0xBEEF;
+  g_td_enumdarr3[0] = THIRD;
+  g_td_intarr5_alias[0] = 99;
+
+  g_td_intptr = &g_tdint;
+  g_td_constintptr = &g_tdint;
+  g_td_floatptr = &g_tdfloat;
+  g_td_doubleptr = &g_tddouble;
+  g_td_tdintptr = &g_tdint2;
+  g_td_tdfloatptr = &g_tdfloat;
+  g_td_tdbyteptr = &g_tdbyte;
+  g_td_consttdintptr = &g_tdint3;
+  g_td_tdintptrptr = &g_td_intptr;
+  g_td_structaptr = &g_td_structa;
+  g_td_conststructaptr = &g_td_structa;
+  g_td_unioneptr = &g_td_unione;
+  g_td_enumdptr = &g_td_enumd;
+
+  g_td_ptr_to_intarr4 = (int (*)[4])&g_td_intarr4;
+  g_td_ptr_to_u32arr3 = (uint32_t (*)[3])&g_td_u32arr3;
+  g_td_ptr_to_tdintarr5 = &g_td_intarr5;
+  g_td_ptr_to_tdintarr4 = &g_td_intarr4;
+
+  g_td_intptrptr = (int**)&g_td_intptr;
+  g_td_constptrconstint = (const int* const*)&g_td_constintptr;
+  g_td_tdintptrptr2 = (TdInt**)&g_td_tdintptr;
+  g_td_intptr2 = &g_tdint;
+  g_td_intptr3 = &g_tdint2;
+
+  g_arr_tdint[0] = g_tdint;
+  g_arr_tdstructa[0].a = 2;
+  g_arr_tdunione[0].b = 0xFACE;
+  g_arr_tdenumd[0] = THIRD;
+  g_arr_tdintptr[0] = &g_tdint;
+  g_arr_tdtdintptr[0] = &g_tdint2;
+
+  g_ptr_tdint = &g_tdint;
+  g_ptr_tdstructa = &g_td_structa;
+  g_ptr_tdintarr5 = &g_td_intarr5;
+  g_ptr_tdint3 = &g_tdint3;
+  g_ptr_tdintptr = &g_td_intptr;
+  g_ptr_tdintarr4 = &g_td_intarr4;
+
+  g_sink_i_c ^= *g_td_intptr ^ *g_td_tdintptr;
+  g_sink_i_c ^= (*g_td_ptr_to_intarr4)[0];
+  g_sink_i_c ^= (int)(*g_td_ptr_to_tdintarr5)[0];
+}
+
+// -----------------------------------------------------------------------------
+// Entry: keep only a handful of locals for xref/stack-var testing
+// -----------------------------------------------------------------------------
+
+int ENTRYPOINT(void) {
+  // only a few locals now, and they're "interesting"
+  struct A a_local = ZINIT;
+  struct BitfieldWeird_C bf_local = g_bfw_text;  // read from .text section
+  union UWeird_C uw_local = g_uw_ro;             // read from rodata
+
+  // assign values to locals (creates xrefs to field layouts)
+  a_local.d = g_u32_data;
+  a_local.n = g_d_ro;
+  a_local.i = true;
+  a_local.o = &g_c_bss;
+  a_local.p = (void***)0;
+  a_local.g = 7;
+  bf_local.us12 = 0xabc;
+
+  // copy locals into globals (forces structured stores and xrefs)
+  v12 = a_local;
+  g_bfw_c = bf_local;
+  g_uw_c = uw_local;
+
+  // global-only touching (no locals)
+  touch_globals_c();
+
+  // ensure void-fn typedef global is actually used
+  g_voidfn_c();
+
+  return (int)(g_sink_u64_c ^ g_sink_u32_c ^ g_sink_u8_c ^
+               (uint64_t)g_sink_i_c);
+}

--- a/tests/dataset/many_types.cpp
+++ b/tests/dataset/many_types.cpp
@@ -1,0 +1,347 @@
+// many_types.cpp
+// C++-only weirdness; reuses everything from many_types.c by including it.
+//
+// Compile with:
+// clang++ -std=c++20 -g3 -gdwarf-4 -O0 -fno-omit-frame-pointer -fno-inline \
+//    -fno-inline-functions -fno-optimize-sibling-calls -fno-strict-aliasing \
+//    -Wall -Wextra -Wno-missing-field-initializers many_types.cpp \
+//    -fstandalone-debug -fno-limit-debug-info \
+//    -fno-eliminate-unused-debug-types -o many_types_cpp
+
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+
+#if defined(__GNUC__) || defined(__clang__)
+#define ATTR_VEC(n) __attribute__((vector_size(n)))
+#define ATTR_MSABI __attribute__((ms_abi))
+#define ATTR_SYSVABI __attribute__((sysv_abi))
+#define USED __attribute__((used))
+#define SECTION(name) __attribute__((section(name)))
+#else
+#define ATTR_VEC(n)
+#define ATTR_MSABI
+#define ATTR_SYSVABI
+#define USED
+#define SECTION(name)
+#endif
+
+#if defined(__clang__)
+#define DO_PRAGMA(x) _Pragma(#x)
+#define CLANG_DIAG_PUSH DO_PRAGMA(clang diagnostic push)
+#define CLANG_DIAG_POP DO_PRAGMA(clang diagnostic pop)
+#define CLANG_IGNORE(w) DO_PRAGMA(clang diagnostic ignored w)
+
+// Use like: CLANG_SUPPRESS("-Wself-assign", statement_without_semicolon)
+#define CLANG_SUPPRESS(w, stmt) \
+  do {                          \
+    CLANG_DIAG_PUSH;            \
+    CLANG_IGNORE(w);            \
+    stmt;                       \
+    CLANG_DIAG_POP;             \
+  } while (0)
+#else
+#define CLANG_SUPPRESS(w, stmt) \
+  do {                          \
+    stmt;                       \
+  } while (0)
+#endif
+
+// Pull in the common C translation unit (types + globals + helper entry).
+#define ENTRYPOINT many_types_c_main  // The C entrypoint
+extern "C" {
+#include "many_types.c"
+}
+
+// -----------------------------------------------------------------------------
+// C++-only enums (underlying types, scoped)
+// -----------------------------------------------------------------------------
+
+enum class E8 : uint8_t { Z0 = 0, Z1 = 1, Z255 = 255 };
+enum class ENeg : int32_t {
+  N0 = 0,
+  N1 = -1,
+  NMin = INT32_MIN,
+  NMax = INT32_MAX
+};
+enum EU64_CPP : uint64_t {
+  U0_CPP = 0,
+  U1_CPP = 1,
+  UTop_CPP = 0xFFFFFFFFFFFFFFFFull
+};
+
+// Enum-typed bitfield (C++ only)
+struct BitfieldWeird_CPP {
+  enum D ed : 2;  // relies on common enum D
+  bool b : 1;
+  unsigned u : 5;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wbitfield-width"
+  char tc : 10;  // Only allowed in C++
+#pragma clang diagnostic pop
+};
+
+// -----------------------------------------------------------------------------
+// ABI-tagged functions (C++ parser stress)
+// -----------------------------------------------------------------------------
+
+extern "C" int ATTR_MSABI msabi_fn(int a, int b) { return a + b; }
+extern "C" int ATTR_SYSVABI sysvabi_fn(int a, int b) { return a - b; }
+
+// -----------------------------------------------------------------------------
+// Vectors + extended integers (compiler-specific)
+// -----------------------------------------------------------------------------
+
+#if defined(__GNUC__) || defined(__clang__)
+typedef int32_t v4i32 ATTR_VEC(16);
+typedef uint8_t v16u8 ATTR_VEC(16);
+#endif
+
+#if defined(__SIZEOF_INT128__)
+using i128 = __int128;
+using u128 = unsigned __int128;
+#endif
+
+// -----------------------------------------------------------------------------
+// Templates / decltype / dependent types (C++ only)
+// -----------------------------------------------------------------------------
+
+template <typename T, size_t N>
+struct TArray {
+  T data[N];
+};
+
+template <typename T>
+struct Identity {
+  using type = T;
+};
+
+template <typename T>
+using IdT = typename Identity<T>::type;
+
+template <typename T>
+struct TemplateWeird {
+  using value_type = T;
+  TArray<T, 3> a;
+  IdT<T> b;
+  decltype(sizeof(T)) sz;
+  T (*fn)(T);
+};
+
+// -----------------------------------------------------------------------------
+// Member pointers, refs, virtuals (C++ only)
+// -----------------------------------------------------------------------------
+
+struct MemberPtrHost {
+  int x;
+  int y;
+  int f(int v) { return x + y + v; }
+  virtual int vf(int) { return 0; }
+};
+
+using MemFnPtr = int (MemberPtrHost::*)(int);
+using MemDataPtr = int MemberPtrHost::*;
+
+using LRefInt = int&;
+using RRefInt = int&&;
+
+// -----------------------------------------------------------------------------
+// Atomics (C++ std::atomic)
+// -----------------------------------------------------------------------------
+
+// moved into a section + marked used
+USED SECTION(".data.weird") std::atomic<uint32_t> a_u32{0};
+USED SECTION(".data.weird") std::atomic<uint8_t> a_u8{0};
+
+// Instantiate template global (forces TemplateWeird<int> and TArray<int,3>)
+USED SECTION(".data.weird") TemplateWeird<int> g_twi_cpp{};
+
+// -----------------------------------------------------------------------------
+// Global sinks + global "use sites" in mixed sections
+// -----------------------------------------------------------------------------
+
+USED SECTION(".data") volatile uint64_t g_sink_u64 = 0;
+USED SECTION(".data") volatile uint32_t g_sink_u32 = 0;
+USED SECTION(".data") volatile uint8_t g_sink_u8 = 0;
+USED SECTION(".data") volatile int g_sink_i = 0;
+
+static int fn_for_template(int x) { return x ^ 0x55; }
+
+// Enums as real global objects (rodata/data/text/bss mix)
+USED SECTION(".rodata") const E8 g_e8_ro = E8::Z255;
+USED SECTION(".text") const ENeg g_en_text = ENeg::N1;  // weird section
+USED ENeg g_en_normal;                                  // normal, uninit
+USED SECTION(".data.weird") EU64_CPP g_eu_data = UTop_CPP;
+USED SECTION(".bss.weird") E8 g_e8_bss;  // uninitialized
+
+// Bitfield struct objects (mix)
+USED SECTION(".bss.weird") BitfieldWeird_CPP g_bf_bss;
+USED SECTION(".text") const BitfieldWeird_CPP g_bf_text = {
+    FIRST, true, 31};  // weird section
+
+// MemberPtrHost + pointer-to-member globals (mix)
+USED SECTION(".data.weird") MemberPtrHost g_mph_data{};
+USED SECTION(".bss.weird") MemberPtrHost g_mph_bss;
+USED SECTION(".rodata") const MemFnPtr g_memfn_ro = &MemberPtrHost::f;
+USED SECTION(".rodata") const MemDataPtr g_memdata_ro = &MemberPtrHost::x;
+
+// Reference typedefs as globals (force int& / int&& into debug info)
+USED SECTION(".data.weird") int g_ref_storage = 123;
+USED SECTION(".data.weird") int g_rref_storage = 456;
+USED LRefInt g_lref_global = g_ref_storage;
+USED RRefInt g_rref_global = static_cast<int&&>(g_rref_storage);
+
+// Template-type globals (ensure all template types materialize as data objects)
+USED SECTION(".data.weird") TArray<int, 3> g_tarray_data = {{1, 2, 3}};
+USED SECTION(".bss.weird")
+    Identity<int> g_identity_bss;  // empty type still becomes a symbol
+USED SECTION(".data.weird") TemplateWeird<int> g_tw_data = {
+    {{0, 0, 0}}, 0, 0, &fn_for_template};
+
+#if defined(__GNUC__) || defined(__clang__)
+struct Pun8 {
+  v16u8 v;
+  uint8_t b[16];
+};
+struct Puni {
+  v4i32 v;
+  int32_t i[4];
+};
+
+USED SECTION(".data.weird") v16u8 g_vecu8_data{};
+USED SECTION(".bss.weird") v4i32 g_veci32_bss{};
+USED SECTION(".data.weird") Pun8 g_pun8{};
+USED SECTION(".data.weird") Puni g_puni{};
+#endif
+
+#if defined(__SIZEOF_INT128__)
+USED SECTION(".data.weird") u128 g_u128_data = (u128)1 << 120;
+USED SECTION(".data.weird") i128 g_i128_data = (i128)-5;
+#endif
+
+// -----------------------------------------------------------------------------
+// Global-only touch routine (no locals): create lots of code->data xrefs
+// -----------------------------------------------------------------------------
+
+static void use_cpp_only_types() {
+  // Enums: force reads/writes from various sections
+  g_e8_bss = E8::Z1;
+  g_sink_u8 ^= static_cast<uint8_t>(g_e8_ro) ^ static_cast<uint8_t>(g_e8_bss);
+  g_sink_i ^= static_cast<int>(g_en_text);
+  g_sink_u64 ^= static_cast<uint64_t>(g_eu_data);
+
+  // Underlying-type facts (compile-time) folded into runtime sinks
+  g_sink_i ^= (std::is_same_v<std::underlying_type_t<E8>, uint8_t> ? 1 : 0);
+  g_sink_i ^= (std::is_same_v<std::underlying_type_t<ENeg>, int32_t> ? 2 : 0);
+
+  // Bitfield objects (write to bss, read from .text const)
+  g_bf_bss.ed = FIRST;
+  g_bf_bss.b = true;
+  g_bf_bss.u = 31;
+  g_sink_u32 ^= (uint32_t)g_bf_bss.u ^ (uint32_t)g_bf_text.u;
+  g_sink_i ^= (int)g_bf_bss.b ^ (int)g_bf_text.b ^ (int)g_bf_bss.ed;
+
+  // Member pointers / virtual / member data using GLOBAL object
+  g_mph_data.x = 1;
+  g_mph_data.y = 2;
+  g_sink_i ^= (g_mph_data.*g_memfn_ro)(3);
+  g_sink_i ^= g_mph_data.*g_memdata_ro;
+  g_sink_i ^= g_mph_data.vf(7);
+
+  // Refs (globals)
+  g_sink_i ^= g_lref_global;
+  g_sink_i ^= g_rref_global;
+
+  // Atomics (globals)
+  a_u32.store(123);
+  a_u8.store(7);
+  g_sink_u32 ^= a_u32.load();
+  g_sink_u8 ^= a_u8.load();
+
+#if defined(__GNUC__) || defined(__clang__)
+  // Vectors via global storage and global pun unions
+  // still forms a use (and keeps it a real object)
+  CLANG_SUPPRESS("-Wself-assign", g_vecu8_data = g_vecu8_data);
+  CLANG_SUPPRESS("-Wself-assign", g_veci32_bss = g_veci32_bss);
+
+  g_pun8.v = g_vecu8_data;
+  g_puni.v = g_veci32_bss;
+
+  g_sink_u8 ^= g_pun8.b[0] ^ g_pun8.b[15];
+  g_sink_i ^= g_puni.i[0] ^ g_puni.i[3];
+#endif
+
+#if defined(__SIZEOF_INT128__)
+  // i128/u128 stored globally; mutate them to force codegen + xrefs
+  g_u128_data += (u128)7;
+  g_i128_data *= (i128)3;
+  g_sink_u64 ^= (uint64_t)(g_u128_data >> 64);
+  g_sink_u64 ^= (uint64_t)g_u128_data;
+  g_sink_u64 ^= (uint64_t)g_i128_data;
+#endif
+
+  // Templates via globals (no locals)
+  g_tw_data.a.data[0] = 1;
+  g_tw_data.a.data[1] = 2;
+  g_tw_data.a.data[2] = 3;
+  g_tw_data.b = 4;
+  g_tw_data.sz = sizeof(int);
+  g_tw_data.fn = &fn_for_template;
+  g_sink_i ^= g_tw_data.fn(g_tw_data.a.data[1] + g_tw_data.b);
+
+  g_twi_cpp.fn = &fn_for_template;
+  g_twi_cpp.a.data[0] = 9;
+  g_twi_cpp.b = 1;
+  g_twi_cpp.sz = sizeof(int);
+  g_sink_i ^= g_twi_cpp.fn(g_twi_cpp.a.data[0]);
+
+  // Also touch other template-type globals so they don't look dead
+  g_sink_i ^= g_tarray_data.data[0] ^ g_tarray_data.data[2];
+  g_sink_u64 ^= (uint64_t)(uintptr_t)&g_identity_bss;
+
+  // ABI-tagged functions: call them (xrefs)
+  g_sink_i ^= msabi_fn(10, 20);
+  g_sink_i ^= sysvabi_fn(30, 5);
+}
+
+// -----------------------------------------------------------------------------
+// Keep only a handful of locals for stack-var/xref testing
+// -----------------------------------------------------------------------------
+
+int main() {
+  // Touch C-side stuff (also generates xrefs into the C globals/types)
+  ENTRYPOINT();
+
+  // Handful of locals for xref/stack-var testing:
+  MemberPtrHost mph_local{};
+  BitfieldWeird_CPP bf_local{};
+  TemplateWeird<int> tw_local{};
+
+  mph_local.x = 5;
+  mph_local.y = 6;
+  bf_local.ed = SECOND;
+  bf_local.b = false;
+  bf_local.u = 17;
+
+  tw_local.a.data[0] = 7;
+  tw_local.a.data[1] = 8;
+  tw_local.a.data[2] = 9;
+  tw_local.b = 10;
+  tw_local.sz = sizeof(int);
+  tw_local.fn = &fn_for_template;
+
+  // Copy locals into globals (field layout stores + xrefs)
+  g_mph_bss = mph_local;
+  g_bf_bss = bf_local;
+  g_tw_data = tw_local;
+
+  // Force uses so debug/type info includes everything, and xrefs are present
+  use_cpp_only_types();
+
+  // Fold locals into sinks so they can't be discarded trivially
+  g_sink_i ^= (mph_local.*g_memfn_ro)(3);
+  g_sink_i ^= (int)bf_local.u;
+  g_sink_i ^= tw_local.fn(tw_local.a.data[0] + tw_local.b);
+
+  return (int)(g_sink_u64 ^ g_sink_u32 ^ g_sink_u8 ^ (uint64_t)g_sink_i);
+}

--- a/tests/dataset/many_types_cpp
+++ b/tests/dataset/many_types_cpp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6de5860dc32ce06522850b61a96158755fa6b77c538c89ba0e3a327211d0d683
-size 166680
+oid sha256:5cb945efbcd4a91b761a7fd04503cdf2fffbe93d8ab6aae82779291ef273d787
+size 168776

--- a/tests/dataset/many_types_cpp.quokka
+++ b/tests/dataset/many_types_cpp.quokka
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b442e5da1982fca5b35e6288b20faf494bd94839cd99d5e5dec64939f9b4ab2
-size 133701
+oid sha256:f18be889e7702ed6e28b5822888b175af2bdd78b3d4477b28a6d1b142e032bbf
+size 168520

--- a/tests/dataset/many_types_cpp_ghidra.quokka
+++ b/tests/dataset/many_types_cpp_ghidra.quokka
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4565ddb2ea59f074176a3aeedba4ef9545cb795dca0eb7b3ac038ff5c8279841
-size 189277
+oid sha256:aeb77c7073e9eab378d5004d8f0925d3afe4790b32df72e00a49b0f3201337ec
+size 220392

--- a/tests/python/tests/offline/test_apply_types.py
+++ b/tests/python/tests/offline/test_apply_types.py
@@ -1,0 +1,245 @@
+"""Tests for apply_types() with mocked IDA APIs."""
+
+import sys
+import types
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# IDA module stubs -- these must be installed before importing ida.py
+# ---------------------------------------------------------------------------
+
+def _install_ida_stubs():
+    """Create minimal IDA module stubs so the backend can be imported."""
+    stubs = {}
+    for mod_name in (
+        "ida_name", "ida_typeinf",
+        "ida_bytes", "ida_funcs", "ida_xref",
+    ):
+        if mod_name not in sys.modules:
+            stubs[mod_name] = MagicMock()
+            sys.modules[mod_name] = stubs[mod_name]
+    return stubs
+
+
+_stubs = _install_ida_stubs()
+
+# Now safe to import
+from quokka.backends.ida import apply_types, _apply_type
+from quokka.data_type import (
+    ArrayType, EnumType, PointerType, StructureType, TypedefType, UnionType, BaseType,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_program_with_types(*type_specs):
+    """Build a minimal Program-like object with the given types.
+
+    Each type_spec is a tuple (TypeClass, name, is_new, extra_kwargs).
+    Returns a mock Program whose .types yields the constructed types.
+    """
+    from quokka.quokka_pb2 import Quokka as Pb
+
+    q = Pb()
+    py_types = []
+
+    for cls, name, is_new, extra in type_specs:
+        t = q.types.add()
+        t.is_new = is_new
+
+        if cls is EnumType:
+            t.enum_type.name = name
+            if "c_str" in extra:
+                t.enum_type.c_str = extra["c_str"]
+            for vname, vval in extra.get("values", []):
+                v = t.enum_type.values.add()
+                v.name = vname
+                v.value = vval
+        else:
+            t.composite_type.name = name
+            if cls is StructureType:
+                t.composite_type.type = Pb.CompositeType.TYPE_STRUCT
+            elif cls is UnionType:
+                t.composite_type.type = Pb.CompositeType.TYPE_UNION
+            elif cls is TypedefType:
+                t.composite_type.type = Pb.CompositeType.TYPE_TYPEDEF
+            elif cls is PointerType:
+                t.composite_type.type = Pb.CompositeType.TYPE_POINTER
+            elif cls is ArrayType:
+                t.composite_type.type = Pb.CompositeType.TYPE_ARRAY
+            t.composite_type.size = extra.get("size", 8)
+            if "c_str" in extra:
+                t.composite_type.c_str = extra["c_str"]
+
+    # Build a mock program that lazily loads from this proto
+    import quokka
+    prog = MagicMock(spec=quokka.Program)
+    prog.proto = q
+    # EnumType.__init__ calls program.get_type(proto.base_type) which must
+    # return a BaseType.  base_type defaults to 0 == BaseType.UNKNOWN.
+    prog.get_type.return_value = BaseType.UNKNOWN
+
+    # Build actual Python type objects
+    for idx, (cls, name, is_new, extra) in enumerate(type_specs):
+        pb_type = q.types[idx]
+        if cls is EnumType:
+            py_types.append(cls(idx, pb_type.enum_type, prog, is_new=is_new))
+        else:
+            py_types.append(cls(idx, pb_type.composite_type, prog, is_new=is_new))
+
+    prog.types = py_types
+    return prog
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_ida_mocks():
+    """Reset all IDA stub mocks before each test."""
+    for mod_name in ("ida_name", "ida_typeinf",
+                     "ida_bytes", "ida_funcs", "ida_xref"):
+        sys.modules[mod_name].reset_mock()
+    yield
+
+
+def test_apply_types_skips_non_new():
+    """Types with is_new=False should not be applied."""
+    prog = _make_program_with_types(
+        (StructureType, "ExistingStruct", False, {"size": 16}),
+    )
+    errors = apply_types(prog)
+    assert errors == 0
+
+
+def test_apply_types_enum_with_c_str():
+    """A new enum with c_str should use parse_decls into the TIL."""
+    prog = _make_program_with_types(
+        (EnumType, "NewEnum", True, {
+            "values": [("A", 0), ("B", 1)],
+            "c_str": "enum NewEnum { A = 0, B = 1 };",
+        }),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0  # success
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_enum_no_c_str():
+    """An enum without c_str should fail (no manual fallback for enums)."""
+    prog = _make_program_with_types(
+        (EnumType, "NoStrEnum", True, {"values": [("X", 0)]}),
+    )
+
+    errors = apply_types(prog)
+    assert errors == 1
+
+
+def test_apply_types_struct_with_c_str():
+    """A new struct with c_str should use parse_decls fast path."""
+    prog = _make_program_with_types(
+        (StructureType, "NewStruct", True, {
+            "size": 8,
+            "c_str": "struct NewStruct { int x; int y; };",
+        }),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0  # success
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_mixed():
+    """Only is_new=True types should be applied; is_new=False skipped."""
+    prog = _make_program_with_types(
+        (StructureType, "Old", False, {"size": 4}),
+        (EnumType, "New", True, {
+            "values": [("V", 1)],
+            "c_str": "enum New { V = 1 };",
+        }),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    # Only the new enum should have been created
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_typedef_with_c_str():
+    """A new typedef with c_str should use parse_decls."""
+    prog = _make_program_with_types(
+        (TypedefType, "MyInt", True, {"size": 4, "c_str": "typedef int MyInt;"}),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0  # success
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_pointer_with_c_str():
+    """A new pointer type with c_str should use parse_decls."""
+    prog = _make_program_with_types(
+        (PointerType, "int_ptr", True, {"size": 8, "c_str": "typedef int *int_ptr;"}),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_array_with_c_str():
+    """A new array type with c_str should use parse_decls."""
+    prog = _make_program_with_types(
+        (ArrayType, "int_arr", True, {"size": 40, "c_str": "typedef int int_arr[10];"}),
+    )
+
+    ida_typeinf = sys.modules["ida_typeinf"]
+    ida_typeinf.get_idati.return_value = MagicMock()
+    ida_typeinf.parse_decls.return_value = 0
+    ida_typeinf.HTI_DCL = 0
+
+    errors = apply_types(prog)
+    assert errors == 0
+    ida_typeinf.parse_decls.assert_called_once()
+
+
+def test_apply_types_no_c_str_error():
+    """A typedef/pointer/array with no c_str should return an error."""
+    prog = _make_program_with_types(
+        (TypedefType, "EmptyTd", True, {"size": 4}),
+    )
+
+    errors = apply_types(prog)
+    assert errors == 1

--- a/tests/python/tests/offline/test_data.py
+++ b/tests/python/tests/offline/test_data.py
@@ -376,3 +376,65 @@ def test_backward_compat_no_typedefs(prog: quokka.Program):
     assert len(prog.fun_names) > 0, "Basic loading should still work"
     types_list = list(prog.types)
     assert len(types_list) > 0, "Types should still be present"
+
+
+# ---------------------------------------------------------------------------
+# is_new field tests
+# ---------------------------------------------------------------------------
+
+
+def test_existing_types_not_is_new(many_types_prog: quokka.Program):
+    """All types from the exporter should have is_new=False."""
+    from quokka.data_type import ComplexType
+    for t in many_types_prog.types:
+        if isinstance(t, ComplexType):
+            assert t.is_new is False, (
+                f"Exported type {t.name} should have is_new=False"
+            )
+
+
+def test_is_new_proto_roundtrip():
+    """is_new should survive a protobuf serialize/deserialize round-trip."""
+    from quokka.quokka_pb2 import Quokka as Pb
+
+    # Build a minimal Quokka with one enum type that has is_new=True
+    q = Pb()
+    t = q.types.add()
+    t.is_new = True
+    t.enum_type.name = "TestEnum"
+    val = t.enum_type.values.add()
+    val.name = "VAL_A"
+    val.value = 0
+
+    # Round-trip through serialization
+    data = q.SerializeToString()
+    q2 = Pb()
+    q2.ParseFromString(data)
+
+    assert q2.types[0].is_new is True
+    assert q2.types[0].enum_type.name == "TestEnum"
+
+
+def test_is_new_false_proto_roundtrip():
+    """is_new=False (default) should survive a round-trip."""
+    from quokka.quokka_pb2 import Quokka as Pb
+
+    q = Pb()
+    t = q.types.add()
+    t.enum_type.name = "NormalEnum"
+
+    data = q.SerializeToString()
+    q2 = Pb()
+    q2.ParseFromString(data)
+
+    assert q2.types[0].is_new is False
+
+
+def test_is_new_not_set_for_primitives(prog: quokka.Program):
+    """Primitive (BaseType) types should not have is_new (they are IntEnums)."""
+    from quokka.data_type import BaseType
+    for t in prog.types:
+        if isinstance(t, BaseType):
+            assert not hasattr(t, "is_new"), (
+                "BaseType should not have is_new attribute"
+            )

--- a/tests/python/tests/offline/test_data.py
+++ b/tests/python/tests/offline/test_data.py
@@ -14,7 +14,7 @@
 import pytest
 
 import quokka
-from quokka.data_type import ArrayType, BaseType, EnumType, PointerType, StructureType, UnionType
+from quokka.data_type import ArrayType, BaseType, EnumType, PointerType, StructureType, TypedefType, UnionType
 
 
 def test_data(prog: quokka.Program):
@@ -228,3 +228,151 @@ def test_pura_update_loads(pura_update_prog: quokka.Program):
     main_func = pura_update_prog.get_function("main")
     assert main_func is not None, "main function should exist"
     assert len(main_func.graph) > 1, "main should have multiple blocks"
+
+
+# ---------------------------------------------------------------------------
+# Typedef type tests
+# ---------------------------------------------------------------------------
+
+
+def test_typedef_type_exists(many_types_prog: quokka.Program):
+    """Typedef types should be present in the type list."""
+    typedefs = [t for t in many_types_prog.types if isinstance(t, TypedefType)]
+    if not typedefs:
+        pytest.skip("No typedef types found in sample")
+    assert len(typedefs) > 0
+
+
+def test_typedef_aliased_type(many_types_prog: quokka.Program):
+    """Typedef's aliased_type should return a valid type."""
+    for t in many_types_prog.types:
+        if isinstance(t, TypedefType):
+            aliased = t.aliased_type
+            assert aliased is not None, f"Typedef {t.name} has no aliased type"
+            break
+    else:
+        pytest.skip("No typedef types found in sample")
+
+
+def test_typedef_resolve(many_types_prog: quokka.Program):
+    """Typedef.resolve() should return a non-typedef concrete type."""
+    for t in many_types_prog.types:
+        if isinstance(t, TypedefType):
+            resolved = t.resolve()
+            assert not isinstance(resolved, TypedefType), (
+                f"resolve() should not return a TypedefType, got {resolved}"
+            )
+            break
+    else:
+        pytest.skip("No typedef types found in sample")
+
+
+def test_typedef_is_typedef(many_types_prog: quokka.Program):
+    """TypedefType.is_typedef should be True."""
+    for t in many_types_prog.types:
+        if isinstance(t, TypedefType):
+            assert t.is_typedef is True
+            assert t.is_struct is False
+            assert t.is_pointer is False
+            break
+    else:
+        pytest.skip("No typedef types found in sample")
+
+
+def test_typedef_has_name(many_types_prog: quokka.Program):
+    """All typedef types should have a non-empty name."""
+    typedefs = [t for t in many_types_prog.types if isinstance(t, TypedefType)]
+    if not typedefs:
+        pytest.skip("No typedef types found in sample")
+    for td in typedefs:
+        assert td.name, f"Typedef at index {td.index} has empty name"
+
+
+def test_typedef_chain_resolution(many_types_prog: quokka.Program):
+    """Chained typedefs (e.g. TdInt -> TdInt2 -> TdInt3) should resolve."""
+    typedefs = {
+        t.name: t
+        for t in many_types_prog.types
+        if isinstance(t, TypedefType)
+    }
+    if "TdInt3" not in typedefs:
+        pytest.skip("TdInt3 typedef not found in sample")
+
+    td3 = typedefs["TdInt3"]
+    resolved = td3.resolve()
+    assert not isinstance(resolved, TypedefType), (
+        f"TdInt3.resolve() returned TypedefType: {resolved}"
+    )
+
+
+def test_typedef_over_struct(many_types_prog: quokka.Program):
+    """A typedef over a struct should resolve to a StructureType."""
+    typedefs = {
+        t.name: t
+        for t in many_types_prog.types
+        if isinstance(t, TypedefType)
+    }
+    if "TdStructA" not in typedefs:
+        pytest.skip("TdStructA typedef not found in sample")
+
+    resolved = typedefs["TdStructA"].resolve()
+    assert isinstance(resolved, StructureType), (
+        f"TdStructA should resolve to StructureType, got {type(resolved).__name__}"
+    )
+
+
+def test_typedef_over_union(many_types_prog: quokka.Program):
+    """A typedef over a union should resolve to a UnionType."""
+    typedefs = {
+        t.name: t
+        for t in many_types_prog.types
+        if isinstance(t, TypedefType)
+    }
+    if "TdUnionE" not in typedefs:
+        pytest.skip("TdUnionE typedef not found in sample")
+
+    resolved = typedefs["TdUnionE"].resolve()
+    assert isinstance(resolved, UnionType), (
+        f"TdUnionE should resolve to UnionType, got {type(resolved).__name__}"
+    )
+
+
+def test_typedef_over_enum(many_types_prog: quokka.Program):
+    """A typedef over an enum should resolve to EnumType or BaseType.
+
+    Enum typedefs may resolve to BaseType.UNKNOWN when the enum lives in a
+    different index space (enums vs composites) and the exporter records
+    element_type_idx = 0 as a fallback.
+    """
+    typedefs = {
+        t.name: t
+        for t in many_types_prog.types
+        if isinstance(t, TypedefType)
+    }
+    if "TdEnumD" not in typedefs:
+        pytest.skip("TdEnumD typedef not found in sample")
+
+    resolved = typedefs["TdEnumD"].resolve()
+    assert isinstance(resolved, (EnumType, BaseType)), (
+        f"TdEnumD should resolve to EnumType or BaseType, got {type(resolved).__name__}"
+    )
+
+
+def test_get_type_resolved(many_types_prog: quokka.Program):
+    """Program.get_type_resolved() should resolve through typedef chains."""
+    for t in many_types_prog.types:
+        if isinstance(t, TypedefType):
+            resolved = many_types_prog.get_type_resolved(t.type_index)
+            assert not isinstance(resolved, TypedefType), (
+                f"get_type_resolved({t.type_index}) returned TypedefType"
+            )
+            break
+    else:
+        pytest.skip("No typedef types found in sample")
+
+
+def test_backward_compat_no_typedefs(prog: quokka.Program):
+    """A .quokka file with no typedefs should still load correctly."""
+    assert len(prog.fun_names) > 0, "Basic loading should still work"
+    types_list = list(prog.types)
+    assert len(types_list) > 0, "Types should still be present"

--- a/tests/python/tests/offline/test_is_exported.py
+++ b/tests/python/tests/offline/test_is_exported.py
@@ -1,0 +1,155 @@
+#  Copyright 2022-2023 Quarkslab
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Tests for the is_exported field on Function.
+
+Verifies that the is_exported flag is correctly round-tripped through
+.quokka files exported by both IDA and Ghidra.
+
+Dataset: many_types_cpp (IDA and Ghidra exports both contain exported functions).
+"""
+
+import pytest
+from pathlib import Path
+
+import quokka
+from quokka.types import FunctionType
+
+
+@pytest.fixture
+def ghidra_many_types_prog(root_directory: Path):
+    binary = root_directory / "tests/dataset/many_types_cpp"
+    quokka_path = root_directory / "tests/dataset/many_types_cpp_ghidra.quokka"
+    if not quokka_path.exists():
+        pytest.skip("Ghidra-exported many_types_cpp.quokka not found")
+    return quokka.Program(quokka_path, binary)
+
+
+class TestIsExportedIDA:
+    """Verify is_exported on IDA-exported .quokka files."""
+
+    def test_has_exported_functions(self, many_types_prog):
+        exported = [
+            f for f in many_types_prog.fun_names.values() if f.is_exported
+        ]
+        assert len(exported) > 0, "Expected at least one exported function"
+
+    def test_has_non_exported_functions(self, many_types_prog):
+        non_exported = [
+            f for f in many_types_prog.fun_names.values() if not f.is_exported
+        ]
+        assert len(non_exported) > 0, "Expected at least one non-exported function"
+
+    def test_start_is_exported(self, many_types_prog):
+        func = many_types_prog.fun_names.get("_start")
+        if func is None:
+            pytest.skip("_start not found in IDA export")
+        assert func.is_exported is True
+
+    def test_main_is_exported(self, many_types_prog):
+        func = many_types_prog.fun_names.get("main")
+        if func is None:
+            pytest.skip("main not found in IDA export")
+        assert func.is_exported is True
+
+    def test_is_exported_is_bool(self, many_types_prog):
+        for func in many_types_prog.fun_names.values():
+            assert isinstance(func.is_exported, bool)
+            break
+
+
+class TestIsExportedGhidra:
+    """Verify is_exported on Ghidra-exported .quokka files."""
+
+    def test_has_exported_functions(self, ghidra_many_types_prog):
+        exported = [
+            f for f in ghidra_many_types_prog.fun_names.values()
+            if f.is_exported
+        ]
+        assert len(exported) > 0, "Expected at least one exported function"
+
+    def test_has_non_exported_functions(self, ghidra_many_types_prog):
+        non_exported = [
+            f for f in ghidra_many_types_prog.fun_names.values()
+            if not f.is_exported
+        ]
+        assert len(non_exported) > 0, "Expected at least one non-exported function"
+
+    def test_start_is_exported(self, ghidra_many_types_prog):
+        func = ghidra_many_types_prog.fun_names.get("_start")
+        if func is None:
+            pytest.skip("_start not found in Ghidra export")
+        assert func.is_exported is True
+
+    def test_main_is_exported(self, ghidra_many_types_prog):
+        func = ghidra_many_types_prog.fun_names.get("main")
+        if func is None:
+            pytest.skip("main not found in Ghidra export")
+        assert func.is_exported is True
+
+
+class TestIsExportedConsistency:
+    """Cross-check IDA and Ghidra exported function sets."""
+
+    def test_exported_function_names_overlap(
+        self, many_types_prog, ghidra_many_types_prog
+    ):
+        """IDA and Ghidra should agree on most exported function names."""
+        ida_exported = {
+            f.name for f in many_types_prog.fun_names.values()
+            if f.is_exported
+        }
+        ghidra_exported = {
+            f.name for f in ghidra_many_types_prog.fun_names.values()
+            if f.is_exported
+        }
+        # Both must have _start exported
+        assert "_start" in ida_exported
+        assert "_start" in ghidra_exported
+
+    def test_non_exported_pura_update(
+        self, pura_update_prog, root_directory: Path
+    ):
+        """puraUpdate has no exported functions in either backend."""
+        ida_exported = [
+            f for f in pura_update_prog.fun_names.values() if f.is_exported
+        ]
+        assert len(ida_exported) == 0
+
+        ghidra_path = root_directory / "tests/dataset/puraUpdate_ghidra.quokka"
+        if not ghidra_path.exists():
+            pytest.skip("Ghidra-exported puraUpdate.quokka not found")
+        binary = root_directory / "tests/dataset/puraUpdate"
+        ghidra_prog = quokka.Program(ghidra_path, binary)
+        ghidra_exported = [
+            f for f in ghidra_prog.fun_names.values() if f.is_exported
+        ]
+        assert len(ghidra_exported) == 0
+
+
+class TestIsExportedProtobuf:
+    """Verify is_exported at the raw protobuf level."""
+
+    def test_proto_field_round_trip(self, many_types_prog):
+        """The proto field should match the Python property."""
+        for proto_func in many_types_prog.proto.functions:
+            # Access the raw protobuf field
+            _ = proto_func.is_exported  # Should not raise
+            break
+
+    def test_proto_has_both_values(self, many_types_prog):
+        """Raw protobuf should contain both True and False values."""
+        values = {f.is_exported for f in many_types_prog.proto.functions}
+        assert True in values, "Expected at least one is_exported=True in proto"
+        assert False in values, "Expected at least one is_exported=False in proto"


### PR DESCRIPTION
## Summary

- Add `TypedefType` to Python bindings for typedef resolution and C-string representation
- Add `is_exported` field on functions with cross-backend (IDA/Ghidra) consistency tests
- Add `is_new` flag on `Type` for IDA apply support with `apply_types()` helper
- Harden CI: path filters, concurrency controls, Ghidra caching, Python version/OS matrix, and several workflow fixes
- Update README and add dataset source files

## Changes

### Python bindings & proto
- New `TypedefType` class with `aliased_type`, `resolve()`, and `c_str()` support
- `is_exported` boolean on functions (proto + Python)
- `is_new` flag on `Type` plus `apply_types()` in `backends/ida.py`
- Proto schema: 3 new fields (`is_new`, `is_exported`, typedef entry)

### CI workflows
- Remove Windows from upload matrix (no artifacts built)
- Run C++ tests on pull requests
- Remove duplicate Ghidra test step (`gradle build` already runs tests)
- Prevent cache poisoning on PR builds
- Add path filters to skip unnecessary runs
- Add concurrency controls to all workflows
- Cache Ghidra download
- Python test matrix: 3.10-3.13 on Ubuntu + macOS
- Skip tool setup on warm cache hit
- Install libmagic on mac OS

### Other
- Add `*.i64` to `.gitignore`
- Update README
- Add `many_types.c` / `many_types.cpp` dataset source files

## Test plan
- [x] Python offline tests pass (77/77)
- [x] C++ unit tests pass (72/72)
- [x] IDA/Ghidra integration tests (require tool availability)
- [x] CI workflows trigger correctly with new path filters
